### PR TITLE
Fix nil values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+helm-docs

--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ controller:
 
 And the descriptions will be picked up and put in the table in the README. The comment need not be near the parameter it
 explains, although this is probably preferable.
+
+### nil values
+If you would like to define a key for a value, but leave the default empty, you can still specify a description for it as well as a type. Like so:
+```yaml
+controller:
+  # controller.replicas -- (int) Number of nginx-ingress pods to load balance between
+  replicas:
+```
+This could be useful when wanting to enforce user-defined values for the chart, where there are no sensible defaults.

--- a/cmd/helm-docs/chart_finder.go
+++ b/cmd/helm-docs/chart_finder.go
@@ -1,34 +1,34 @@
 package main
 
 import (
-    "os"
-    "path/filepath"
-    "strings"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 var ignoreDirectories = map[string]bool{
-    ".git": true,
-    "templates": true,
+	".git":      true,
+	"templates": true,
 }
 
 func findChartDirectories() []string {
-    var chartDirs []string
+	var chartDirs []string
 
-    filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-        if err != nil {
-            return err
-        }
+	filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 
-        if info.IsDir() && ignoreDirectories[path] {
-            return filepath.SkipDir
-        }
+		if info.IsDir() && ignoreDirectories[path] {
+			return filepath.SkipDir
+		}
 
-        if strings.HasSuffix(path, "Chart.yaml") {
-            chartDirs = append(chartDirs, filepath.Dir(path))
-        }
+		if strings.HasSuffix(path, "Chart.yaml") {
+			chartDirs = append(chartDirs, filepath.Dir(path))
+		}
 
-        return nil
-    })
+		return nil
+	})
 
-    return chartDirs
+	return chartDirs
 }

--- a/cmd/helm-docs/chart_info.go
+++ b/cmd/helm-docs/chart_info.go
@@ -1,149 +1,148 @@
 package main
 
 import (
-    "bufio"
-    "gopkg.in/yaml.v2"
-    "io/ioutil"
-    "log"
-    "os"
-    "path"
-    "regexp"
+	"bufio"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"regexp"
 )
 
 var valuesDescriptionRegex = regexp.MustCompile("# (.*) -- (.*)")
 
 type ChartMetaMaintainer struct {
-    Email string
-    Name string
+	Email string
+	Name  string
 }
 
 type ChartMeta struct {
-    ApiVersion string `yaml:"apiVersion"`
-    Name string
-    Description string
-    Version string
-    Home string
-    Sources []string
-    Engine string
-    Maintainers []ChartMetaMaintainer
+	ApiVersion  string `yaml:"apiVersion"`
+	Name        string
+	Description string
+	Version     string
+	Home        string
+	Sources     []string
+	Engine      string
+	Maintainers []ChartMetaMaintainer
 }
 
 type ChartRequirementsItem struct {
-    Name string
-    Version string
-    Repository string
+	Name       string
+	Version    string
+	Repository string
 }
 
 type ChartRequirements struct {
-    Dependencies []ChartRequirementsItem
+	Dependencies []ChartRequirementsItem
 }
 
 type ChartValues map[interface{}]interface{}
 
-
 func getYamlFileContents(filename string, debug bool) ([]byte, error) {
-    if _, err := os.Stat(filename); os.IsNotExist(err) {
-        return nil, err
-    }
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return nil, err
+	}
 
-    yamlFileContents, err := ioutil.ReadFile(filename)
+	yamlFileContents, err := ioutil.ReadFile(filename)
 
-    if err != nil {
-        panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 
-    if debug {
-        log.Printf("Reading %s file contents:\n%s\n", filename, yamlFileContents)
-    }
+	if debug {
+		log.Printf("Reading %s file contents:\n%s\n", filename, yamlFileContents)
+	}
 
-    return []byte(yamlFileContents), nil
+	return []byte(yamlFileContents), nil
 }
 
 func yamlLoadAndCheck(yamlFileContents []byte, out interface{}) {
-    err := yaml.Unmarshal(yamlFileContents, out)
+	err := yaml.Unmarshal(yamlFileContents, out)
 
-    if err != nil {
-        panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 }
 
 func isErrorInReadingNecessaryFile(filePath string, loadError error) bool {
-    if loadError != nil {
-        if os.IsNotExist(loadError) {
-            log.Printf("Required chart file %s missing. Skipping documentation for chart", filePath)
-            return true
-        } else {
-            log.Printf("Error occurred in reading chart file %s. Skipping documentation for chart", filePath)
-            return true
-        }
-    }
+	if loadError != nil {
+		if os.IsNotExist(loadError) {
+			log.Printf("Required chart file %s missing. Skipping documentation for chart", filePath)
+			return true
+		} else {
+			log.Printf("Error occurred in reading chart file %s. Skipping documentation for chart", filePath)
+			return true
+		}
+	}
 
-    return false
+	return false
 }
 
 func parseChartFile(chartDirectory string, debug bool) (ChartMeta, error) {
-    chartYamlPath := path.Join(chartDirectory, "Chart.yaml")
-    chartMeta := ChartMeta{}
-    yamlFileContents, err := getYamlFileContents(chartYamlPath, debug)
+	chartYamlPath := path.Join(chartDirectory, "Chart.yaml")
+	chartMeta := ChartMeta{}
+	yamlFileContents, err := getYamlFileContents(chartYamlPath, debug)
 
-    if isErrorInReadingNecessaryFile(chartYamlPath, err) {
-        return chartMeta, err
-    }
+	if isErrorInReadingNecessaryFile(chartYamlPath, err) {
+		return chartMeta, err
+	}
 
-    yamlLoadAndCheck(yamlFileContents, &chartMeta)
-    return chartMeta, nil
+	yamlLoadAndCheck(yamlFileContents, &chartMeta)
+	return chartMeta, nil
 }
 
 func parseChartRequirementsFile(chartDirectory string, debug bool) (ChartRequirements, error) {
-    requirementsPath := path.Join(chartDirectory, "requirements.yaml")
-    if _, err := os.Stat(requirementsPath); os.IsNotExist(err) {
-        return ChartRequirements{Dependencies: []ChartRequirementsItem{}}, nil
-    }
+	requirementsPath := path.Join(chartDirectory, "requirements.yaml")
+	if _, err := os.Stat(requirementsPath); os.IsNotExist(err) {
+		return ChartRequirements{Dependencies: []ChartRequirementsItem{}}, nil
+	}
 
-    chartRequirements := ChartRequirements{}
-    yamlFileContents, err := getYamlFileContents(requirementsPath, debug)
+	chartRequirements := ChartRequirements{}
+	yamlFileContents, err := getYamlFileContents(requirementsPath, debug)
 
-    if isErrorInReadingNecessaryFile(requirementsPath, err) {
-        return chartRequirements, err
-    }
+	if isErrorInReadingNecessaryFile(requirementsPath, err) {
+		return chartRequirements, err
+	}
 
-    yamlLoadAndCheck(yamlFileContents, &chartRequirements)
-    return chartRequirements, nil
+	yamlLoadAndCheck(yamlFileContents, &chartRequirements)
+	return chartRequirements, nil
 }
 
 func parseValuesFile(chartDirectory string, debug bool) (ChartValues, error) {
-    valuesPath := path.Join(chartDirectory, "values.yaml")
-    values := ChartValues{}
-    yamlFileContents, err := getYamlFileContents(valuesPath, debug)
+	valuesPath := path.Join(chartDirectory, "values.yaml")
+	values := ChartValues{}
+	yamlFileContents, err := getYamlFileContents(valuesPath, debug)
 
-    if isErrorInReadingNecessaryFile(valuesPath, err) {
-        return values, err
-    }
+	if isErrorInReadingNecessaryFile(valuesPath, err) {
+		return values, err
+	}
 
-    yamlLoadAndCheck(yamlFileContents, &values)
-    return values, nil
+	yamlLoadAndCheck(yamlFileContents, &values)
+	return values, nil
 }
 
 func parseValuesFileComments(chartDirectory string) (map[string]string, error) {
-    valuesPath := path.Join(chartDirectory, "values.yaml")
-    valuesFile, err := os.Open(valuesPath)
+	valuesPath := path.Join(chartDirectory, "values.yaml")
+	valuesFile, err := os.Open(valuesPath)
 
-    if isErrorInReadingNecessaryFile(valuesPath, err) {
-        return map[string]string{}, err
-    }
+	if isErrorInReadingNecessaryFile(valuesPath, err) {
+		return map[string]string{}, err
+	}
 
-    defer valuesFile.Close()
+	defer valuesFile.Close()
 
-    keyToDescriptions := make(map[string]string)
-    scanner := bufio.NewScanner(valuesFile)
+	keyToDescriptions := make(map[string]string)
+	scanner := bufio.NewScanner(valuesFile)
 
-    for scanner.Scan() {
-        match := valuesDescriptionRegex.FindStringSubmatch(scanner.Text())
+	for scanner.Scan() {
+		match := valuesDescriptionRegex.FindStringSubmatch(scanner.Text())
 
-        if len(match) > 2 {
-            keyToDescriptions[match[1]] = match[2]
-        }
-    }
+		if len(match) > 2 {
+			keyToDescriptions[match[1]] = match[2]
+		}
+	}
 
-    return keyToDescriptions, nil
+	return keyToDescriptions, nil
 }

--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -1,46 +1,45 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    flag "github.com/spf13/pflag"
+	"fmt"
+	flag "github.com/spf13/pflag"
+	"os"
 )
 
 type HelmDocArgs struct {
-    help bool
-    debug bool
-    dryRun bool
+	help   bool
+	debug  bool
+	dryRun bool
 }
-
 
 const debugHelp = "Print debug output"
 const dryRunHelp = "Don't actually render any markdown files with docs, juts print to stdout"
 const helpHelp = "Print this help menu, then exist"
 
 func printHelp() {
-    fmt.Println("Usage:")
-    fmt.Println("  helm-doc [options]")
-    fmt.Println()
-    fmt.Println("helm-doc reads the values file of a chart in the root of your repository and creates a table of the values")
-    fmt.Println()
-    fmt.Println("Options:")
-    fmt.Println(fmt.Sprintf("  --debug         %s", debugHelp))
-    fmt.Println(fmt.Sprintf("  --dry-run       %s", dryRunHelp))
-    fmt.Println(fmt.Sprintf("  --help          %s", helpHelp))
+	fmt.Println("Usage:")
+	fmt.Println("  helm-doc [options]")
+	fmt.Println()
+	fmt.Println("helm-doc reads the values file of a chart in the root of your repository and creates a table of the values")
+	fmt.Println()
+	fmt.Println("Options:")
+	fmt.Println(fmt.Sprintf("  --debug         %s", debugHelp))
+	fmt.Println(fmt.Sprintf("  --dry-run       %s", dryRunHelp))
+	fmt.Println(fmt.Sprintf("  --help          %s", helpHelp))
 }
 
 func parseCommandLine() HelmDocArgs {
-    var args HelmDocArgs
+	var args HelmDocArgs
 
-    flag.BoolVar(&args.debug, "debug", false, debugHelp)
-    flag.BoolVar(&args.dryRun, "dry-run", false, dryRunHelp)
-    flag.BoolVar(&args.help, "help", false, helpHelp)
-    flag.Parse()
+	flag.BoolVar(&args.debug, "debug", false, debugHelp)
+	flag.BoolVar(&args.dryRun, "dry-run", false, dryRunHelp)
+	flag.BoolVar(&args.help, "help", false, helpHelp)
+	flag.Parse()
 
-    if args.help {
-        printHelp()
-        os.Exit(0)
-    }
+	if args.help {
+		printHelp()
+		os.Exit(0)
+	}
 
-    return args
+	return args
 }

--- a/cmd/helm-docs/generate.go
+++ b/cmd/helm-docs/generate.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -99,9 +100,31 @@ func createAtomRow(value interface{}, prefix string, keysToDescriptions map[stri
 			Default:     "{}",
 			Description: description,
 		}
+	case nil:
+		return parseNilValueType(prefix, description)
 	}
 
 	return ValueRow{}
+}
+
+func parseNilValueType(prefix string, description string) ValueRow {
+	// Grab whatever's in between the parentheses of the description and treat it as the type
+	r, _ := regexp.Compile("^\\(.*?\\)")
+	t := r.FindString(description)
+
+	if len(t) > 0 {
+		t = t[1 : len(t)-1]
+		description = description[len(t)+3:]
+	} else {
+		t = STRING_TYPE
+	}
+
+	return ValueRow{
+		Key:         prefix,
+		Type:        t,
+		Default:     "<nil>",
+		Description: description,
+	}
 }
 
 func createListRows(values []interface{}, prefix string, keysToDescriptions map[string]string) []ValueRow {
@@ -175,6 +198,8 @@ func createValueRows(values ChartValues, prefix string, keysToDescriptions map[s
 		case int:
 			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
 		case string:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		default:
 			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
 		}
 	}

--- a/cmd/helm-docs/generate.go
+++ b/cmd/helm-docs/generate.go
@@ -1,21 +1,21 @@
 package main
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "path/filepath"
-    "sort"
-    "strings"
-    "strconv"
-    "sync"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 type ValueRow struct {
-    Key string
-    Type string
-    Default string
-    Description string
+	Key         string
+	Type        string
+	Default     string
+	Description string
 }
 
 const BOOL_TYPE = "bool"
@@ -27,232 +27,239 @@ const STRING_TYPE = "string"
 
 const ROW_FORMAT = "| %s | %s | %s | %s |\n"
 
-
 func printRequirementsHeader(f *os.File) {
-    f.WriteString("| Repository | Name | Version |\n")
-    f.WriteString("|------------|------|---------|\n")
+	f.WriteString("| Repository | Name | Version |\n")
+	f.WriteString("|------------|------|---------|\n")
 }
 
 func requirementKey(requirement ChartRequirementsItem) string {
-    return fmt.Sprintf("%s/%s", requirement.Repository, requirement.Name)
+	return fmt.Sprintf("%s/%s", requirement.Repository, requirement.Name)
 }
 
 func printRequirementsRows(outputFile *os.File, requirements ChartRequirements) {
-    sort.Slice(requirements.Dependencies[:], func(i, j int) bool {
-        return requirementKey(requirements.Dependencies[i]) < requirementKey(requirements.Dependencies[j])
-    })
+	sort.Slice(requirements.Dependencies[:], func(i, j int) bool {
+		return requirementKey(requirements.Dependencies[i]) < requirementKey(requirements.Dependencies[j])
+	})
 
-    for _, r := range requirements.Dependencies {
-        outputFile.WriteString(fmt.Sprintf("| %s | %s | %s |\n", r.Repository, r.Name, r.Version))
-    }
+	for _, r := range requirements.Dependencies {
+		outputFile.WriteString(fmt.Sprintf("| %s | %s | %s |\n", r.Repository, r.Name, r.Version))
+	}
 
-    outputFile.WriteString("\n\n")
+	outputFile.WriteString("\n\n")
 }
 
 func printValuesHeader(outputFile *os.File) {
-    outputFile.WriteString("| Key | Type | Default | Description |\n")
-    outputFile.WriteString("|-----|------|---------|-------------|\n")
+	outputFile.WriteString("| Key | Type | Default | Description |\n")
+	outputFile.WriteString("|-----|------|---------|-------------|\n")
 }
 
 func createAtomRow(value interface{}, prefix string, keysToDescriptions map[string]string) ValueRow {
-    description := keysToDescriptions[prefix]
+	description := keysToDescriptions[prefix]
 
-    switch value.(type) {
-        case bool:
-            return ValueRow {
-                Key: prefix,
-                Type: BOOL_TYPE,
-                Default: fmt.Sprintf("%t", value),
-                Description: description,
-            }
-        case float64:
-            return ValueRow {
-                Key: prefix,
-                Type: FLOAT_TYPE,
-                Default: strconv.FormatFloat(value.(float64), 'f', -1, 64),
-                Description: description,
-            }
-        case int:
-            return ValueRow {
-                Key: prefix,
-                Type: INT_TYPE,
-                Default: fmt.Sprintf("%d", value),
-                Description: description,
-            }
-        case string:
-            return ValueRow {
-                Key: prefix,
-                Type: STRING_TYPE,
-                Default: fmt.Sprintf("\"%s\"", value),
-                Description: description,
-            }
-        case []interface{}:
-            return ValueRow {
-                Key: prefix,
-                Type: LIST_TYPE,
-                Default: "[]",
-                Description: description,
-            }
-        case ChartValues:
-            return ValueRow {
-                Key: prefix,
-                Type: OBJECT_TYPE,
-                Default: "{}",
-                Description: description,
-            }
-    }
+	switch value.(type) {
+	case bool:
+		return ValueRow{
+			Key:         prefix,
+			Type:        BOOL_TYPE,
+			Default:     fmt.Sprintf("%t", value),
+			Description: description,
+		}
+	case float64:
+		return ValueRow{
+			Key:         prefix,
+			Type:        FLOAT_TYPE,
+			Default:     strconv.FormatFloat(value.(float64), 'f', -1, 64),
+			Description: description,
+		}
+	case int:
+		return ValueRow{
+			Key:         prefix,
+			Type:        INT_TYPE,
+			Default:     fmt.Sprintf("%d", value),
+			Description: description,
+		}
+	case string:
+		return ValueRow{
+			Key:         prefix,
+			Type:        STRING_TYPE,
+			Default:     fmt.Sprintf("\"%s\"", value),
+			Description: description,
+		}
+	case []interface{}:
+		return ValueRow{
+			Key:         prefix,
+			Type:        LIST_TYPE,
+			Default:     "[]",
+			Description: description,
+		}
+	case ChartValues:
+		return ValueRow{
+			Key:         prefix,
+			Type:        OBJECT_TYPE,
+			Default:     "{}",
+			Description: description,
+		}
+	}
 
-    return ValueRow{}
+	return ValueRow{}
 }
 
 func createListRows(values []interface{}, prefix string, keysToDescriptions map[string]string) []ValueRow {
-    if len(values) == 0 {
-        return []ValueRow {createAtomRow(values, prefix, keysToDescriptions)}
-    }
+	if len(values) == 0 {
+		return []ValueRow{createAtomRow(values, prefix, keysToDescriptions)}
+	}
 
-    valueRows := []ValueRow {}
+	valueRows := []ValueRow{}
 
-    for i, v := range values {
-        var nextPrefix string
-        if prefix != "" {
-            nextPrefix = fmt.Sprintf("%s[%d]", prefix, i)
-        } else {
-            nextPrefix = fmt.Sprintf("[%d]", i)
-        }
+	for i, v := range values {
+		var nextPrefix string
+		if prefix != "" {
+			nextPrefix = fmt.Sprintf("%s[%d]", prefix, i)
+		} else {
+			nextPrefix = fmt.Sprintf("[%d]", i)
+		}
 
-        switch v.(type) {
-            case ChartValues:
-                valueRows = append(valueRows, createValueRows(v.(ChartValues), nextPrefix, keysToDescriptions)...)
-            case []interface{}:
-                valueRows = append(valueRows, createListRows(v.([]interface{}), nextPrefix, keysToDescriptions)...)
-            case bool:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-            case float64:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-            case int:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-            case string:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-                break
-        }
-    }
+		switch v.(type) {
+		case ChartValues:
+			valueRows = append(valueRows, createValueRows(v.(ChartValues), nextPrefix, keysToDescriptions)...)
+		case []interface{}:
+			valueRows = append(valueRows, createListRows(v.([]interface{}), nextPrefix, keysToDescriptions)...)
+		case bool:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		case float64:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		case int:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		case string:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+			break
+		}
+	}
 
-    return valueRows
+	return valueRows
 }
 
 func createValueRows(values ChartValues, prefix string, keysToDescriptions map[string]string) []ValueRow {
-    if len(values) == 0 {
-        return []ValueRow {createAtomRow(values, prefix, keysToDescriptions)}
-    }
+	if len(values) == 0 {
+		return []ValueRow{createAtomRow(values, prefix, keysToDescriptions)}
+	}
 
-    valueRows := []ValueRow {}
+	valueRows := []ValueRow{}
 
-    for k, v := range values {
-        var escapedKey string
-        var nextPrefix string
+	for k, v := range values {
+		var escapedKey string
+		var nextPrefix string
 
-        key := k.(string)
-        if strings.Contains(key, ".") {
-            escapedKey = fmt.Sprintf("\"%s\"", k)
-        } else {
-            escapedKey = key
-        }
+		key := k.(string)
+		if strings.Contains(key, ".") {
+			escapedKey = fmt.Sprintf("\"%s\"", k)
+		} else {
+			escapedKey = key
+		}
 
-        if prefix != "" {
-            nextPrefix = fmt.Sprintf("%s.%s", prefix, escapedKey)
-        } else {
-            nextPrefix = fmt.Sprintf("%s", escapedKey)
-        }
+		if prefix != "" {
+			nextPrefix = fmt.Sprintf("%s.%s", prefix, escapedKey)
+		} else {
+			nextPrefix = fmt.Sprintf("%s", escapedKey)
+		}
 
-        switch v.(type) {
-            case ChartValues:
-                valueRows = append(valueRows, createValueRows(v.(ChartValues), nextPrefix, keysToDescriptions)...)
-            case []interface{}:
-                valueRows = append(valueRows, createListRows(v.([]interface{}), nextPrefix, keysToDescriptions)...)
-            case bool:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-            case float64:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-            case int:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-            case string:
-                valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
-        }
-    }
+		switch v.(type) {
+		case ChartValues:
+			valueRows = append(valueRows, createValueRows(v.(ChartValues), nextPrefix, keysToDescriptions)...)
+		case []interface{}:
+			valueRows = append(valueRows, createListRows(v.([]interface{}), nextPrefix, keysToDescriptions)...)
+		case bool:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		case float64:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		case int:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		case string:
+			valueRows = append(valueRows, createAtomRow(v, nextPrefix, keysToDescriptions))
+		}
+	}
 
-    sort.Slice(valueRows[:], func(i, j int) bool {
-        return valueRows[i].Key < valueRows[j].Key
-    })
+	sort.Slice(valueRows[:], func(i, j int) bool {
+		return valueRows[i].Key < valueRows[j].Key
+	})
 
-    return valueRows
+	return valueRows
 }
 
 func printValueRows(f *os.File, values ChartValues, keysToDescriptions map[string]string) {
-    valueRows := createValueRows(values, "", keysToDescriptions)
-    for _, valueRow := range valueRows {
-        f.WriteString(fmt.Sprintf(ROW_FORMAT, valueRow.Key, valueRow.Type, valueRow.Default, valueRow.Description))
-    }
+	valueRows := createValueRows(values, "", keysToDescriptions)
+	for _, valueRow := range valueRows {
+		f.WriteString(fmt.Sprintf(ROW_FORMAT, valueRow.Key, valueRow.Type, valueRow.Default, valueRow.Description))
+	}
 }
 
 func withNewline(s string) string {
-    return fmt.Sprintln(s)
+	return fmt.Sprintln(s)
 }
 
 func getOutputFile(chartDirectory string, dryRun bool) (*os.File, error) {
-    if dryRun {
-        return os.Stdout, nil
-    }
+	if dryRun {
+		return os.Stdout, nil
+	}
 
-    f, err := os.Create(fmt.Sprintf("%s/README.md", chartDirectory))
+	f, err := os.Create(fmt.Sprintf("%s/README.md", chartDirectory))
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    return f, err
+	return f, err
 }
 
 func printDocumentation(chartDirectory string, debug bool, dryRun bool, waitGroup *sync.WaitGroup) {
-    defer waitGroup.Done()
-    log.Printf("Generating README Documentation for chart %s", chartDirectory)
+	defer waitGroup.Done()
+	log.Printf("Generating README Documentation for chart %s", chartDirectory)
 
-    outputFile, err := getOutputFile(chartDirectory, dryRun)
-    if err != nil {
-        log.Printf("Could not open chart README file %s, skipping chart", filepath.Join(chartDirectory, "README.md"))
-        return
-    }
+	outputFile, err := getOutputFile(chartDirectory, dryRun)
+	if err != nil {
+		log.Printf("Could not open chart README file %s, skipping chart", filepath.Join(chartDirectory, "README.md"))
+		return
+	}
 
-    if !dryRun {
-        defer outputFile.Close()
-    }
+	if !dryRun {
+		defer outputFile.Close()
+	}
 
-    chartMeta, err := parseChartFile(chartDirectory, debug)
-    if err != nil { return }
+	chartMeta, err := parseChartFile(chartDirectory, debug)
+	if err != nil {
+		return
+	}
 
-    chartRequirements, err := parseChartRequirementsFile(chartDirectory, debug)
-    if err != nil { return }
+	chartRequirements, err := parseChartRequirementsFile(chartDirectory, debug)
+	if err != nil {
+		return
+	}
 
-    values, err := parseValuesFile(chartDirectory, debug)
-    if err != nil { return }
+	values, err := parseValuesFile(chartDirectory, debug)
+	if err != nil {
+		return
+	}
 
-    keysToDescriptions, err := parseValuesFileComments(chartDirectory)
-    if err != nil { return }
+	keysToDescriptions, err := parseValuesFileComments(chartDirectory)
+	if err != nil {
+		return
+	}
 
-    outputFile.WriteString(withNewline(chartMeta.Name))
-    outputFile.WriteString(withNewline(strings.Repeat("=", len(chartMeta.Name))))
-    outputFile.WriteString(withNewline(chartMeta.Description))
+	outputFile.WriteString(withNewline(chartMeta.Name))
+	outputFile.WriteString(withNewline(strings.Repeat("=", len(chartMeta.Name))))
+	outputFile.WriteString(withNewline(chartMeta.Description))
 
-    if chartMeta.Home != "" {
-        outputFile.WriteString(fmt.Sprintf("\nThis chart's source code can be found [here](%s)\n\n\n", chartMeta.Home))
-    }
+	if chartMeta.Home != "" {
+		outputFile.WriteString(fmt.Sprintf("\nThis chart's source code can be found [here](%s)\n\n\n", chartMeta.Home))
+	}
 
-    if len(chartRequirements.Dependencies) > 0 {
-        outputFile.WriteString("## Chart Requirements\n\n")
-        printRequirementsHeader(outputFile)
-        printRequirementsRows(outputFile, chartRequirements)
-    }
+	if len(chartRequirements.Dependencies) > 0 {
+		outputFile.WriteString("## Chart Requirements\n\n")
+		printRequirementsHeader(outputFile)
+		printRequirementsRows(outputFile, chartRequirements)
+	}
 
-    outputFile.WriteString("## Chart Values\n\n")
-    printValuesHeader(outputFile)
-    printValueRows(outputFile, values, keysToDescriptions)
+	outputFile.WriteString("## Chart Values\n\n")
+	printValuesHeader(outputFile)
+	printValueRows(outputFile, values, keysToDescriptions)
 }

--- a/cmd/helm-docs/main.go
+++ b/cmd/helm-docs/main.go
@@ -1,22 +1,21 @@
 package main
 
 import (
-    "log"
-    "strings"
-    "sync"
+	"log"
+	"strings"
+	"sync"
 )
 
-
 func main() {
-    args := parseCommandLine()
-    chartDirs := findChartDirectories()
-    log.Printf("Found Chart directories [%s]", strings.Join(chartDirs, ", "))
-    waitGroup := sync.WaitGroup{}
+	args := parseCommandLine()
+	chartDirs := findChartDirectories()
+	log.Printf("Found Chart directories [%s]", strings.Join(chartDirs, ", "))
+	waitGroup := sync.WaitGroup{}
 
-    for _, c := range chartDirs {
-        waitGroup.Add(1)
-        go printDocumentation(c, args.debug, args.dryRun, &waitGroup)
-    }
+	for _, c := range chartDirs {
+		waitGroup.Add(1)
+		go printDocumentation(c, args.debug, args.dryRun, &waitGroup)
+	}
 
-    waitGroup.Wait()
+	waitGroup.Wait()
 }

--- a/example-chart/README.md
+++ b/example-chart/README.md
@@ -25,4 +25,4 @@ This chart's source code can be found [here](https://github.com/norwoodj/helm-do
 | controller.persistentVolumeClaims | list | [] | List of persistent volume claims to create |
 | controller.podLabels | object | {} | The labels to be applied to instances of the controller pod |
 | controller.publishService.enabled | bool | false | Whether to expose the ingress controller to the public world |
-| controller.replicas | int | 2 | Number of nginx-ingress pods to load balance between |
+| controller.replicas | int | nil | Number of nginx-ingress pods to load balance between |

--- a/example-chart/values.yaml
+++ b/example-chart/values.yaml
@@ -23,5 +23,5 @@ controller:
     # controller.publishService.enabled -- Whether to expose the ingress controller to the public world
     enabled: false
 
-  # controller.replicas -- Number of nginx-ingress pods to load balance between
-  replicas: 2
+  # controller.replicas -- (int) Number of nginx-ingress pods to load balance between
+  replicas:


### PR DESCRIPTION
Ensures documentation for values that do not specify a default.

Allows for type definition of the nil value by parsing the beginning of the description and looking for the type inside of parentheses, e.g.:

```
# controller.replicas -- (int) Number of nginx-ingress pods to load balance between
  replicas:
```
would be parsed as an int value