### PR TITLE
explicitly document lists and maps when there are elements defined inside of them

### DIFF
--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -93,11 +93,11 @@ func parseNilValueType(prefix string, description string) valueRow {
 }
 
 func createListRows(prefix string, values []interface{}, keysToDescriptions map[string]string) []valueRow {
-	if len(values) == 0 {
-		return []valueRow{createAtomRow(prefix, values, keysToDescriptions)}
-	}
+	valueRows := []valueRow{createAtomRow(prefix, values, keysToDescriptions)}
 
-	valueRows := []valueRow{}
+	if len(values) == 0 {
+		return valueRows
+	}
 
 	for i, v := range values {
 		var nextPrefix string
@@ -128,15 +128,15 @@ func createListRows(prefix string, values []interface{}, keysToDescriptions map[
 }
 
 func createValueRows(prefix string, values helm.ChartValues, keysToDescriptions map[string]string) []valueRow {
-	if len(values) == 0 {
-		if prefix == "" {
-			return []valueRow{}
-		}
+	valueRows := make([]valueRow, 0)
 
-		return []valueRow{createAtomRow(prefix, values, keysToDescriptions)}
+	if prefix != "" {
+		valueRows = append(valueRows, createAtomRow(prefix, values, keysToDescriptions))
 	}
 
-	valueRows := make([]valueRow, 0)
+	if len(values) == 0 {
+		return valueRows
+	}
 
 	for k, v := range values {
 		var escapedKey string


### PR DESCRIPTION
Hi,
Currently when there is a map or a list that has values inside of it, the list/map is not documented.  In my values.yaml I have lists that have default elements defined inside, but these lists could still be extended by the user.  For this reason I still want the documentation for the list itself to be included.  This pr adds this functionality.  If you would like I could try to put this functionality behind a couple of run time flags?  

Thank you for writing this awesome tool!

Example:
```yaml
# exampleObj -- this is an example object that I would like documented
exampleObj:
  # exampleObj.key -- this is a specific key on the object I would also like documented
  key: value
# exampleList -- this is an example list
exampleList:
    # exampleList[0] -- the first element in the list
    # exampleList[0].objectInList -- this is an object inside of the list
  - objectInList:
    # exampleList[0].name -- this is an element on the object inside of the list
    name: "object in list"
```
currently helm-docs generates:

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| exampleList[0].name | string | "object in list" | this is an element on the object inside of the list |
| exampleList[0].objectInList | string | \<nil\> | this is an object inside of the list |
| exampleObj.key | string | "value" | this is a specific key on the object I would also like documented |

this pr will generate:

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| exampleList | list | [] | this is an example list |
| exampleList[0] | object | {} | the first element in the list |
| exampleList[0].name | string | "object in list" | this is an element on the object inside of the list |
| exampleList[0].objectInList | string | \<nil\> | this is an object inside of the list |
| exampleObj | object | {} | this is an example object that I would like documented |
| exampleObj.key | string | "value" | this is a specific key on the object I would also like documented |