### PR TITLE
add option to ignore a directory when finding charts

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -45,6 +45,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	logLevelUsage := fmt.Sprintf("Level of logs that should printed, one of (%s)", strings.Join(possibleLogLevels(), ", "))
 	command.PersistentFlags().BoolP("dry-run", "d", false, "don't actually render any markdown files just print to stdout passed")
 	command.PersistentFlags().StringP("template-file", "t", "README.md.gotmpl", "gotemplate file to use to generate documentation for charts")
+	command.PersistentFlags().StringP("ignore-dir", "i", "", "directory to ignore when finding charts")
 	command.PersistentFlags().StringP("log-level", "l", "info", logLevelUsage)
 
 	viper.AutomaticEnv()

--- a/cmd/helm-docs/main.go
+++ b/cmd/helm-docs/main.go
@@ -27,7 +27,10 @@ func retrieveInfoAndPrintDocumentation(chartDirectory string, waitGroup *sync.Wa
 
 func helmDocs(_ *cobra.Command, _ []string) {
 	initializeCli()
-	chartDirs, err := helm.FindChartDirectories()
+
+	ignoreDir := viper.GetString("ignore-dir")
+
+	chartDirs, err := helm.FindChartDirectories(ignoreDir)
 
 	if err != nil {
 		log.Errorf("Error finding chart directories: %s", err)

--- a/pkg/helm/chart_finder.go
+++ b/pkg/helm/chart_finder.go
@@ -11,8 +11,12 @@ var ignoreDirectories = map[string]bool{
 	"templates": true,
 }
 
-func FindChartDirectories() ([]string, error) {
+func FindChartDirectories(ignoreDirectory string) ([]string, error) {
 	chartDirs := make([]string, 0)
+
+	if ignoreDirectory != "" {
+		ignoreDirectories[ignoreDirectory] = true
+	}
 
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
fixes https://github.com/norwoodj/helm-docs/issues/12

$ /tmp/helm-docs/helm-docs
INFO[2019-08-06T18:18:40-04:00] Found Chart directories [., charts/subchart1, charts/subchart2]
INFO[2019-08-06T18:18:40-04:00] Generating README Documentation for chart charts/subchart2
INFO[2019-08-06T18:18:40-04:00] Generating README Documentation for chart charts/subchart1
INFO[2019-08-06T18:18:40-04:00] Generating README Documentation for chart .

$ /tmp/helm-docs/helm-docs -i charts
INFO[2019-08-06T18:18:45-04:00] Found Chart directories [.]
INFO[2019-08-06T18:18:45-04:00] Generating README Documentation for chart .