### PR TITLE
Add support for custom default values and doc comment continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,13 @@ controller:
     # controller.publishService.enabled -- Whether to expose the ingress controller to the public world
     enabled: false
 
-  # controller.replicas -- Number of nginx-ingress pods to load balance between
+  # controller.replicas -- Number of nginx-ingress pods to load balance between.
+  # Do not set this below 2.
   replicas: 2
 ```
+
+Note that comments can continue on the next line. In that case leave out the double dash, and the lines will simply be
+appended with a space in-between.
 
 The following rules are used to determine which values will be added to the values table in the README:
 
@@ -168,6 +172,22 @@ controller:
   replicas:
 ```
 This could be useful when wanting to enforce user-defined values for the chart, where there are no sensible defaults.
+
+### Default values/column
+In cases where you do not want to include the default value from `values.yaml`, or where the real default is calculated
+inside the chart, you can change the contents of the column like so:
+
+```yaml
+service:
+  # service.annotations -- Add annotations to the service
+  # @default -- the chart will add some internal annotations automatically
+  annotations: []
+```
+
+The order is important. The name must be spelled just like the column heading. The first comment must be the
+one specifying the key. The "@default" comment must follow.
+
+See [here](./example-charts/custom-template/values.yaml) for an example.
 
 ### Spaces and Dots in keys
 If a key name contains any "." or " " characters, that section of the path must be quoted in description comments e.g.

--- a/example-charts/custom-template/README.md
+++ b/example-charts/custom-template/README.md
@@ -29,7 +29,7 @@ culpa qui officia deserunt mollit anim id est laborum.
 | controller.image.tag | string | `"18.0831"` |  |
 | controller.ingressClass | string | `"nginx"` | Name of the ingress class to route through this controller |
 | controller.name | string | `"controller"` |  |
-| controller.persistentVolumeClaims | list | `[]` | List of persistent volume claims to create |
+| controller.persistentVolumeClaims | list | Use this to override the default value specified here in the file | List of persistent volume claims to create. For very long comments, break them into multiple lines. |
 | controller.podLabels | object | `{}` | The labels to be applied to instances of the controller pod |
 | controller.publishService.enabled | bool | `false` | Whether to expose the ingress controller to the public world |
 | controller.replicas | int | `nil` | Number of nginx-ingress pods to load balance between |

--- a/example-charts/custom-template/values.yaml
+++ b/example-charts/custom-template/values.yaml
@@ -4,7 +4,9 @@ controller:
     repository: nginx-ingress-controller
     tag: "18.0831"
 
-  # controller.persistentVolumeClaims -- List of persistent volume claims to create
+  # controller.persistentVolumeClaims -- List of persistent volume claims to create.
+  # For very long comments, break them into multiple lines.
+  # @default -- Use this to override the default value specified here in the file
   persistentVolumeClaims: []
 
   extraVolumes:


### PR DESCRIPTION
This PR adds support for doc comments continuation over multiple lines and default values in doc comments.

The feature was previously discussed here https://github.com/norwoodj/helm-docs/issues/22.

It is a rebirth of the previous PR opened by @Grannath here https://github.com/norwoodj/helm-docs/pull/25. Thanks for the great work !

This adds unit tests, hardens the regexes used to implement doc comments continuation to reduce the risk of mistakenly combining multiple comment lines.

Doc has been updated along with example charts.