### PR TITLE
fix: renders <, >, and & characters from default values correctly (fi…

### DIFF
--- a/example-charts/special-characters/Chart.yaml
+++ b/example-charts/special-characters/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: special-characters
+description: A chart demonstrating handling of special characters in values files
+version: "0.2.0"
+home: "https://github.com/norwoodj/helm-docs/tree/master/example-charts/special-characters"
+sources: ["https://github.com/norwoodj/helm-docs/tree/master/example-charts/special-characters"]
+engine: gotpl
+type: application
+maintainers:
+  - email: norwood.john.m@gmail.com
+    name: John Norwood

--- a/example-charts/special-characters/README.md
+++ b/example-charts/special-characters/README.md
@@ -1,0 +1,19 @@
+special-characters
+==================
+A chart demonstrating handling of special characters in values files
+
+Current chart version is `0.2.0`
+
+Source code can be found [here](https://github.com/norwoodj/helm-docs/tree/master/example-charts/special-characters)
+
+
+
+## Chart Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| elasticsearch.clusterHealthCheckParams | string | `"wait_for_status=yellow&timeout=1s"` | The Elasticsearch cluster health status params that will be used by readinessProbe command |
+| elasticsearch.clusterHealthCheckParamsDescription | string | `""` | Now let's put some special characters in the description: wait_for_status=yellow&timeout=1s |
+| htmlSnippets.one | string | `"<html>\n  <head></head>\n  <body>\n    <h1>Is this right, I don't know html</h1>\n  </body>\n</html>\n"` |  |
+| htmlSnippets.three | string | `"<html><head></head></html>"` | Another description |
+| htmlSnippets.two | string | `""` | Let's put it in the description <html></html> |

--- a/example-charts/special-characters/values.yaml
+++ b/example-charts/special-characters/values.yaml
@@ -1,0 +1,22 @@
+elasticsearch:
+  # elasticsearch.clusterHealthCheckParams -- The Elasticsearch cluster health status params that will be used by readinessProbe command
+  clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+
+  # elasticsearch.clusterHealthCheckParamsDescription -- Now let's put some special characters in the description: wait_for_status=yellow&timeout=1s
+  clusterHealthCheckParamsDescription: ""
+
+htmlSnippets:
+  one: |
+    <html>
+      <head></head>
+      <body>
+        <h1>Is this right, I don't know html</h1>
+      </body>
+    </html>
+
+  # htmlSnippets.two -- Let's put it in the description <html></html>
+  two: ""
+
+  # htmlSnippets.three -- Another description
+  # @default -- "<html><head></head></html>"
+  three: ""


### PR DESCRIPTION
…xes #24)