### PR TITLE
Add CI/CD pipelines and deb/rpm packaging options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - "*"
+    tags-ignore:
+    - "*"
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v2-beta
+      with:
+        go-version: '^1.14.1'
+    - uses: actions/cache@v1
+      with:
+        path: /home/runner/go/pkg/mod
+        key: go-mod
+    - uses: goreleaser/goreleaser-action@v1
+      with:
+        args: release --snapshot --skip-sign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - "*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v2-beta
+      with:
+        go-version: '^1.14.1'
+    - uses: actions/cache@v1
+      with:
+        path: /home/runner/go/pkg/mod
+        key: go-mod
+    - name: Login to Docker hub
+      run: docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
+    - uses: goreleaser/goreleaser-action@v1
+      with:
+        args: release
+        key: ${{ secrets.SIGNING_KEY }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,21 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+signs:
+- artifacts: checksum
+  args: ["-u", "<thefingerprintid>", "--output", "${signature}", "--detach-sign", "${artifact}"]
+
+nfpms:
+- vendor: helm-docs
+  homepage: https://github.com/norwoodj/helm-docs
+  maintainer: norwoodj
+  description: A tool for automatically generating markdown documentation for helm charts
+  license: GNU General Public License v3.0
+  formats:
+  - deb
+  - rpm
+
 brews:
   - github:
       owner: norwoodj

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ test:
 .PHONY: clean
 clean:
 	rm -f helm-docs
+
+.PHONY: dist
+dist:
+	goreleaser release --rm-dist --snapshot --skip-sign


### PR DESCRIPTION
## What's included

* Adds Github Actions workflows to compile, test and build helm-docs within PRs and all branches
* Adds Goreleaser release automation that is only triggered upon push Git tags
* Adds Deb/Rpm packages to the release artifacts, so that users can install it using `dpkg -i` and the rpm equivalent. No additional dependency besides `goreleaser` is necessary for local development. The packages will install the binary in `/usr/local/bin` by default (see https://goreleaser.com/customization/#NFPM)
* Configures artifact checksum signing with GPG, so users can verify the downloads (instructions to set up below)
* Adds an additional Makefile target `dist`

## Why

* [GitHub Actions usage is free for public repositories](https://help.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions)
* It's faster and better documented than Travis CI
* Deb/Rpm packaging options gives better (un)installability and versioning for free (besides Docker)
* CI/CD improves code quality, it gives confidence when merging PRs
* Helm-docs is an awesome project :)

## What you need to do before merging

### Set up signing key
1. Create a new passwordless GPG key, e.g. `gpg --quick-generate-key helm-docs default default never` (Do NOT use your personal private key!)
2. Get the ID of the new key:
`gpg --list-keys`, the id looks like `E57761BCB035C49A7068EF97083880A377733DD7`
3. Export the private key of the new GPG key for signing, e.g.
`gpg --armor --export-secret-key E57761BCB035C49A7068EF97083880A377733DD7`
4. Save the content of the private key as a secret named `SIGNING_KEY` in https://github.com/norwoodj/helm-docs/settings/secrets (it begins with `-----BEGIN PGP PRIVATE KEY BLOCK-----`)
5. Check in the public key (`gpg --armor --export E57761BCB035C49A7068EF97083880A377733DD7 > signature.asc`) somewhere in this Repo, e.g. `.github/signature.asc` or in the project root dir, file name/extension also doesn't matter, it's just a proposal. So that users can verify the downloads with the public key.
6. Leave a comment in this PR with the GPG Id, so I can replace the placeholder in `.goreleaser.yml`:
```yaml
signs:
- artifacts: checksum
  args: ["-u", "<thefingerprintid>", "--output", "${signature}", "--detach-sign", "${artifact}"]
```
(or you can do it directly in your own commit, I don't mind)

This only takes around 15min to do ;)

### Set up CI/CD

1. Add a new secret named `DOCKER_HUB_USER` in https://github.com/norwoodj/helm-docs/settings/secrets (it's probably jnorwood like your Docker Hub repo, but for good measure, should it change somehow)
2. Create a new personal access token on [Docker Hub](https://hub.docker.com/settings/security) (it's revocable in any case)
3. Store the token as `DOCKER_HUB_PASSWORD` in the secrets

(Note: Secrets do NOT get passed to PR builds or printed in CI output, so your Docker Hub access isn't leaked.)

