### PR TITLE
fix: Updating hook config for README.md.gotmpl

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   args: []
   description: Uses 'helm-docs' to create documentation from the Helm chart's 'values.yaml' file, and inserts the result into a corresponding 'README.md' file.
   entry: git-hook/helm-docs
-  files: (Chart|requirements|values)\.yaml$
+  files: (README\.md\.gotmpl|(Chart|requirements|values)\.yaml)$
   language: script
   name: Helm Docs
   require_serial: true

--- a/README.md
+++ b/README.md
@@ -265,5 +265,4 @@ pre-commit install
 pre-commit install-hooks
 ```
 
-Future changes to your charts requirements.yaml, values.yaml, or Chart.yaml files will cause an update to documentation when
-you commit.
+Future changes to your chart's `requirements.yaml`, `values.yaml`, `Chart.yaml`, or `README.md.gotmpl` files will cause an update to documentation when you commit.


### PR DESCRIPTION
# Description

While working on https://github.com/norwoodj/helm-docs/issues/48, I noticed that changes to `README.md.gotmpl` did not trigger the `pre-commit` hooks.

The `pre-commit` hooks should be triggered when there is a change to the underlying `README.md.gotmpl` file; otherwise, changes to this template will not trigger a rebuild of the `README.md` file.