### PR TITLE
fix: GitHub token for Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         args: release
         key: ${{ secrets.SIGNING_KEY }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.NORWOODJ_ORG_TOKEN }}


### PR DESCRIPTION
# Description

This release action (https://github.com/norwoodj/helm-docs/runs/955815074) failed because the token is wrong.

The token needs to be one that has access to write to the https://github.com/norwoodj/homebrew-tap repository. Using the default `secrets.GITHUB_TOKEN` token is wrong because it only has access to write to the _current_ repository, and nothing else.

@norwoodj Can you create a personal access token with the `repo` scope enabled as it says in the instructions here please (https://goreleaser.com/environment/#api-tokens) ? It should go in a secret named `NORWOODJ_ORG_TOKEN `. 