### PR TITLE
add support for sorting based on presence in file

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -48,7 +48,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	command.PersistentFlags().StringP("log-level", "l", "info", logLevelUsage)
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")
 	command.PersistentFlags().StringP("template-file", "t", "README.md.gotmpl", "gotemplate file path relative to each chart directory from which documentation will be generated")
-	command.PersistentFlags().StringP("sort", "s", "file", "order in which to print the values (alpha or file)")
+	command.PersistentFlags().StringP("sort-values-order", "s", "alpha", "order in which to print the values (alpha or file)")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_DOCS")

--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -48,6 +48,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	command.PersistentFlags().StringP("log-level", "l", "info", logLevelUsage)
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")
 	command.PersistentFlags().StringP("template-file", "t", "README.md.gotmpl", "gotemplate file path relative to each chart directory from which documentation will be generated")
+	command.PersistentFlags().StringP("sort", "s", "file", "order in which to print the values (alpha or file)")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_DOCS")

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -9,6 +9,7 @@ type valueRow struct {
 	Type        string
 	Default     string
 	Description string
+	Order       int
 }
 
 type chartTemplateData struct {

--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/norwoodj/helm-docs/pkg/helm"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -84,6 +85,7 @@ func parseNilValueType(key string, description helm.ChartValueDescription) value
 		Type:        t,
 		Default:     description.Default,
 		Description: description.Description,
+		Order:       description.Order,
 	}
 }
 
@@ -124,6 +126,7 @@ func createValueRow(
 		Type:        getTypeName(value),
 		Default:     defaultValue,
 		Description: description.Description,
+		Order:       description.Order,
 	}, nil
 }
 
@@ -256,10 +259,15 @@ func createValueRowsFromObject(
 		valueRows = append(valueRows, valueRowsForObjectField...)
 	}
 
+	sortType := viper.GetString("sort")
 	// At the top level of recursion, sort value rows by key
 	if prefix == "" {
 		sort.Slice(valueRows[:], func(i, j int) bool {
-			return valueRows[i].Key < valueRows[j].Key
+			if sortType == "file" {
+				return valueRows[i].Order < valueRows[j].Order
+			} else {
+				return valueRows[i].Key < valueRows[j].Key
+			}
 		})
 	}
 

--- a/pkg/helm/chart_info.go
+++ b/pkg/helm/chart_info.go
@@ -49,6 +49,7 @@ type ChartRequirements struct {
 }
 
 type ChartValueDescription struct {
+	Order       int
 	Description string
 	Default     string
 }
@@ -171,6 +172,7 @@ func parseChartValuesFileComments(chartDirectory string) (map[string]ChartValueD
 	keyToDescriptions := make(map[string]ChartValueDescription)
 	scanner := bufio.NewScanner(valuesFile)
 	foundValuesComment := false
+	currentIndex := 0
 
 	for scanner.Scan() {
 		currentLine := scanner.Text()
@@ -196,8 +198,9 @@ func parseChartValuesFileComments(chartDirectory string) (map[string]ChartValueD
 			keyToDescriptions[key] = ChartValueDescription{
 				Description: description,
 				Default:     match[1],
+				Order:       currentIndex,
 			}
-
+			currentIndex++
 			foundValuesComment = false
 			continue
 		}
@@ -213,7 +216,9 @@ func parseChartValuesFileComments(chartDirectory string) (map[string]ChartValueD
 		// the in progress value to the map, and reset to looking for a new key
 		keyToDescriptions[key] = ChartValueDescription{
 			Description: description,
+			Order:       currentIndex,
 		}
+		currentIndex++
 
 		foundValuesComment = false
 	}


### PR DESCRIPTION
This adds a command-line flag, `--sort`, which allows the user to sort either alphabetically, or based on the ordering of values in the values.yaml file.

I've defaulted to `--sort=file` here, as I think that would be the more desired behavior. But I'm happy to revert to using `alpha` as the default.