### PR TITLE
Adding more OS and architecture types

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,17 @@ builds:
   - main: ./cmd/helm-docs
     env:
       - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+    goos:
+      - darwin
+      - linux
+      - windows
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ nfpms:
   - rpm
 
 brews:
-  - github:
+  - tap:
       owner: norwoodj
       name: homebrew
     folder: Formula


### PR DESCRIPTION
# Description

- Resolves https://github.com/norwoodj/helm-docs/issues/51, adding not only Windows support, but also adding ARM / ARM64 types as well.
- Resolves the deprecation notice that comes with using the old `github` keyword in the `brews` section (see here: https://goreleaser.com/deprecations/#brewsgithub).