### PR TITLE
Parse requirement's alias and display "alias(name)" if 'alias' not empty

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -167,7 +167,11 @@ func getRequirementsTableTemplates() string {
 	requirementsSectionBuilder.WriteString("| Repository | Name | Version |\n")
 	requirementsSectionBuilder.WriteString("|------------|------|---------|\n")
 	requirementsSectionBuilder.WriteString("  {{- range .Dependencies }}")
+	requirementsSectionBuilder.WriteString("  {{ if .Alias }}")
+	requirementsSectionBuilder.WriteString("\n| {{ .Repository }} | {{ .Alias }}({{ .Name }}) | {{ .Version }} |")
+	requirementsSectionBuilder.WriteString("  {{ else }}")
 	requirementsSectionBuilder.WriteString("\n| {{ .Repository }} | {{ .Name }} | {{ .Version }} |")
+	requirementsSectionBuilder.WriteString("  {{ end }}")
 	requirementsSectionBuilder.WriteString("  {{- end }}")
 	requirementsSectionBuilder.WriteString("{{ end }}")
 

--- a/pkg/helm/chart_info.go
+++ b/pkg/helm/chart_info.go
@@ -42,6 +42,7 @@ type ChartRequirementsItem struct {
 	Name       string
 	Version    string
 	Repository string
+	Alias      string
 }
 
 type ChartRequirements struct {


### PR DESCRIPTION
This allows for charts using dependencies to have documentation showing their aliases (if defined).
This is handy when several dependencies use the same chart with different aliases.

Before 

| Repository | Name | Version |
|------------|------|---------| 
| repo| dependency1 | 0.1.0 |   
| repo | sharedchart | 0.1.0|   
| repo | sharedchart | 0.1.0|   
| repo | sharedchart | 0.1.0|   

after

| Repository | Name | Version |
|------------|------|---------| 
| repo| dependency1 | 0.1.0 |   
| repo | dependency2(sharedchart) | 0.1.0|   
| repo | dependency3(sharedchart) | 0.1.0|   
| repo | dependency4(sharedchart) | 0.1.0|   