### PR TITLE
Add badges section

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The default internal template mentioned above uses many of these and looks like 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+{{ template "chart.badgesSection" . }}
 
 {{ template "chart.description" . }}
 

--- a/example-charts/full-template/README.md
+++ b/example-charts/full-template/README.md
@@ -50,6 +50,10 @@ application
 
 ![AppVersion: 13.0.0](https://img.shields.io/badge/AppVersion-13.0.0-informational?style=flat-square)
 
+## `chart.badgesSection`
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 13.0.0](https://img.shields.io/badge/AppVersion-13.0.0-informational?style=flat-square)
+
 ## `chart.homepage`
 
 https://github.com/norwoodj/helm-docs/tree/master/example-charts/full-template

--- a/example-charts/full-template/README.md.gotmpl
+++ b/example-charts/full-template/README.md.gotmpl
@@ -40,6 +40,10 @@
 
 {{ template "chart.appVersionBadge" . }}
 
+## `chart.badgesSection`
+
+{{ template "chart.badgesSection" . }}
+
 ## `chart.homepage`
 
 {{ template "chart.homepage" . }}

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -1,12 +1,13 @@
 package document
 
 import (
-	"github.com/norwoodj/helm-docs/pkg/util"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"text/template"
+
+	"github.com/norwoodj/helm-docs/pkg/util"
 
 	"github.com/Masterminds/sprig"
 	log "github.com/sirupsen/logrus"
@@ -89,6 +90,15 @@ func getAppVersionTemplate() string {
 	appVersionBuilder.WriteString("{{ end }}")
 
 	return appVersionBuilder.String()
+}
+
+func getBadgesTemplates() string {
+	badgeBuilder := strings.Builder{}
+	badgeBuilder.WriteString(`{{ define "chart.badgesSection" }}`)
+	badgeBuilder.WriteString(`{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}`)
+	badgeBuilder.WriteString("{{ end }}")
+
+	return badgeBuilder.String()
 }
 
 func getDescriptionTemplate() string {
@@ -271,6 +281,7 @@ func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, te
 		getHeaderTemplate(),
 		getDeprecatedTemplate(),
 		getAppVersionTemplate(),
+		getBadgesTemplates(),
 		getDescriptionTemplate(),
 		getVersionTemplates(),
 		getTypeTemplate(),

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -18,7 +18,7 @@ import (
 const defaultDocumentationTemplate = `{{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+{{ template "chart.badgesSection" . }}
 
 {{ template "chart.description" . }}
 


### PR DESCRIPTION
This PR adds a `badgesSection` template. It's useful if you want to define a custom set of badges and don't want to copy-paste them to every template.

For example: I usually add a kubeVersion and an artifact hub badge as well.

PS. I wasn't sure how the examples are supposed to be updated. Using the locally built binary generated a bunch of unrelated changes.