### PR TITLE
Support Apple M1 / Multi-Arch Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.15.6'
+        go-version: '^1.16.3'
     - uses: actions/cache@v1
       with:
         path: /home/runner/go/pkg/mod
         key: go-mod
-    - uses: goreleaser/goreleaser-action@v1
+    - uses: goreleaser/goreleaser-action@v2
       with:
         args: release --snapshot --skip-sign

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,14 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-buildx-action@v1
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.16.3'
@@ -24,3 +30,5 @@ jobs:
     - uses: goreleaser/goreleaser-action@v2
       with:
         args: release --snapshot --skip-sign
+    - if: always()
+      run: rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,14 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-buildx-action@v1
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.16.3'
@@ -25,3 +31,5 @@ jobs:
         key: ${{ secrets.SIGNING_KEY }}
       env:
         GITHUB_TOKEN: ${{ secrets.NORWOODJ_ORG_TOKEN }}
+    - if: always()
+      run: rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.15.6'
+        go-version: '^1.16.3'
     - uses: actions/cache@v1
       with:
         path: /home/runner/go/pkg/mod
         key: go-mod
     - name: Login to Docker hub
       run: docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
-    - uses: goreleaser/goreleaser-action@v1
+    - uses: goreleaser/goreleaser-action@v2
       with:
         args: release
         key: ${{ secrets.SIGNING_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,9 @@ nfpms:
   formats:
   - deb
   - rpm
+  replacements:
+    amd64: x86_64
+    linux: Linux
 
 brews:
   - tap:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,6 +67,47 @@ dockers:
   - goos: linux
     goarch: amd64
     dockerfile: Dockerfile
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/amd64
     image_templates:
-      - jnorwood/{{ .ProjectName }}:latest
-      - jnorwood/{{ .ProjectName }}:{{ .Tag }}
+      - jnorwood/{{ .ProjectName }}:{{ .Tag }}-amd64
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/arm64
+    image_templates:
+      - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64
+  - goos: linux
+    goarch: arm
+    goarm: 6
+    dockerfile: Dockerfile
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/arm/v6
+    image_templates:
+      - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v6
+  - goos: linux
+    goarch: arm
+    goarm: 7
+    dockerfile: Dockerfile
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/arm/v7
+    image_templates:
+      - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v7
+docker_manifests:
+- name_template: jnorwood/{{ .ProjectName }}:{{ .Tag }}
+  image_templates:
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-amd64
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v6
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v7
+- name_template: jnorwood/{{ .ProjectName }}:latest
+  image_templates:
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-amd64
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v6
+    - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v7


### PR DESCRIPTION
# Description

Solves https://github.com/norwoodj/helm-docs/issues/94.

- The GoReleaser action and the Go version are updated to support builds for Apple Silicon
- Multi-arch Docker images have been added
  - https://carlosbecker.com/posts/multi-platform-docker-images-goreleaser-gh-actions/
  - https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/