### PR TITLE
Avoid raw URLs in maintainer tables

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -128,7 +128,7 @@ func getMaintainersTemplate() string {
 	maintainerBuilder.WriteString("| Name | Email | Url |\n")
 	maintainerBuilder.WriteString("| ---- | ------ | --- |\n")
 	maintainerBuilder.WriteString("  {{- range .Maintainers }}")
-	maintainerBuilder.WriteString("\n| {{ .Name }} | {{ .Email }} | {{ .Url }} |")
+	maintainerBuilder.WriteString("\n| {{ .Name }} | <{{ .Email }}> | <{{ .Url }}> |")
 	maintainerBuilder.WriteString("  {{- end }}")
 	maintainerBuilder.WriteString("{{ end }}")
 


### PR DESCRIPTION
Markdown linters like markdownlint fail by default on raw URLs. Wrap
maintainer table URLs in angle brackets to follow this norm and avoid
failures.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>