### PR TITLE
fix type definition when description is empty

### DIFF
--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -84,7 +84,11 @@ func parseNilValueType(key string, description helm.ChartValueDescription, autoD
 
 	if len(t) > 0 {
 		t = t[1 : len(t)-1]
-		description.Description = description.Description[len(t)+3:]
+		if len(description.Description) > len(t)+3 {
+			description.Description = description.Description[len(t)+3:]
+		} else {
+			description.Description = ""
+		}
 	} else {
 		t = stringType
 	}

--- a/pkg/document/values_test.go
+++ b/pkg/document/values_test.go
@@ -931,18 +931,20 @@ animals:
   birds:
   birdCount:
   nonWeirdCats:
+  undescribedCount:
 	`)
 
 	descriptions := map[string]helm.ChartValueDescription{
-		"animals.birdCount":    {Description: "(int) the number of birds we have"},
-		"animals.birds":        {Description: "(list) the list of birds we have"},
-		"animals.nonWeirdCats": {Description: "the cats that we have that are not weird"},
+		"animals.birdCount":        {Description: "(int) the number of birds we have"},
+		"animals.birds":            {Description: "(list) the list of birds we have"},
+		"animals.nonWeirdCats":     {Description: "the cats that we have that are not weird"},
+		"animals.undescribedCount": {Description: "(int)"},
 	}
 
 	valuesRows, err := getSortedValuesTableRows(helmValues, descriptions)
 
 	assert.Nil(t, err)
-	assert.Len(t, valuesRows, 3)
+	assert.Len(t, valuesRows, 4)
 
 	assert.Equal(t, "animals.birdCount", valuesRows[0].Key)
 	assert.Equal(t, intType, valuesRows[0].Type)
@@ -964,6 +966,13 @@ animals:
 	assert.Equal(t, "", valuesRows[2].AutoDefault)
 	assert.Equal(t, "the cats that we have that are not weird", valuesRows[2].Description)
 	assert.Equal(t, "", valuesRows[2].AutoDescription)
+
+	assert.Equal(t, "animals.undescribedCount", valuesRows[3].Key)
+	assert.Equal(t, intType, valuesRows[3].Type)
+	assert.Equal(t, "`nil`", valuesRows[3].Default)
+	assert.Equal(t, "", valuesRows[3].AutoDefault)
+	assert.Equal(t, "", valuesRows[3].Description)
+	assert.Equal(t, "", valuesRows[3].AutoDescription)
 }
 
 func TestNilValuesWithDefaults(t *testing.T) {


### PR DESCRIPTION
Fixes #103