### PR TITLE
improve formatting of values table

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -210,7 +210,7 @@ func getValuesTableTemplates() string {
 	valuesSectionBuilder.WriteString("| Key | Type | Default | Description |\n")
 	valuesSectionBuilder.WriteString("|-----|------|---------|-------------|\n")
 	valuesSectionBuilder.WriteString("  {{- range .Values }}")
-	valuesSectionBuilder.WriteString("\n| {{ .Key }} | {{ .Type }} | {{ .Default | default .AutoDefault }} | {{ .Description | default .AutoDescription }} |")
+	valuesSectionBuilder.WriteString(`\n| {{ .Key | replace "." ".&ZeroWidthSpace;" }} | {{ .Type }} | {{ .Default | default .AutoDefault }} | {{ .Description | default .AutoDescription }} |`)
 	valuesSectionBuilder.WriteString("  {{- end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -210,7 +210,7 @@ func getValuesTableTemplates() string {
 	valuesSectionBuilder.WriteString("| Key | Type | Default | Description |\n")
 	valuesSectionBuilder.WriteString("|-----|------|---------|-------------|\n")
 	valuesSectionBuilder.WriteString("  {{- range .Values }}")
-	valuesSectionBuilder.WriteString("\n| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |")
+	valuesSectionBuilder.WriteString("\n| {{ .Key }} | {{ .Type }} | {{ .Default | default .AutoDefault }} | {{ .Description | default .AutoDescription }} |")
 	valuesSectionBuilder.WriteString("  {{- end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 


### PR DESCRIPTION
Deeply nested values can cause the values table to grow really wide. The key field is not wrapped by default. Example: https://github.com/cortexproject/cortex-helm-chart/blob/cc9ef3dc/README.md#values

By adding zero-width spaces after the `.`s in the keys, the browser will wrap long keys when needed. Here's an example, notice the table is much narrower and much more readable:
https://github.com/cortexproject/cortex-helm-chart/blob/f6454e5/README.md#values