### PR TITLE
Add a benchmark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to helm-docs
+
+## Testing
+
+### Benchmarks
+
+If you are working on a feature that is likely to impact performance, consider running benchmarks
+and comparing the results before and after your change.
+
+To run benchmarks, run the command:
+
+```
+go test -run=^$ -bench=. ./cmd/helm-docs
+```

--- a/cmd/helm-docs/main_test.go
+++ b/cmd/helm-docs/main_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/norwoodj/helm-docs/pkg/document"
+)
+
+// BenchmarkHelmDocs benchmarks the entire helm-docs command by running on testdata.
+//
+// To run benchmarks, run the command:
+//
+//   go test -run=^$ -bench=. ./cmd/helm-docs
+//
+func BenchmarkHelmDocs(b *testing.B) {
+	// Copy testdata to a new temporary directory, to keep the working directory clean.
+	tmp := copyToTempDir(b, os.DirFS(filepath.Join("testdata", "benchmark")))
+
+	// Bind commandline flags.
+	// NOTE: Flags must be specified even if they use the default value.
+	if err := viper.BindFlagValues(testFlagSet{
+		"chart-search-root":          tmp,
+		"log-level":                  "warn",
+		"ignore-file":                ".helmdocsignore",
+		"output-file":                "README.md",
+		"sort-values-order":          document.AlphaNumSortOrder,
+		"document-dependency-values": true,
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	// Benchmark the main function.
+	for n := 0; n < b.N; n++ {
+		helmDocs(nil, nil)
+	}
+}
+
+var _ viper.FlagValueSet = &testFlagSet{}
+
+type testFlagSet map[string]interface{}
+
+func (s testFlagSet) VisitAll(fn func(viper.FlagValue)) {
+	for k, v := range s {
+		flagVal := &testFlagValue{
+			name:  k,
+			value: fmt.Sprintf("%v", v),
+		}
+		switch v.(type) {
+		case bool:
+			flagVal.typ = "bool"
+		default:
+			flagVal.typ = "string"
+		}
+		fn(flagVal)
+	}
+}
+
+var _ viper.FlagValue = &testFlagValue{}
+
+type testFlagValue struct {
+	name  string
+	value string
+	typ   string
+}
+
+func (v *testFlagValue) HasChanged() bool {
+	return false
+}
+
+func (v *testFlagValue) Name() string {
+	return v.name
+}
+
+func (v *testFlagValue) ValueString() string {
+	return v.value
+}
+
+func (v *testFlagValue) ValueType() string {
+	return v.typ
+}
+
+// copyToTempDir copies the specified readonly filesystem into a new temporary directory and returns
+// the path to the temporary directory. It fails the benchmark on any error and handles cleanup when
+// the benchmark finishes.
+func copyToTempDir(b *testing.B, fsys fs.FS) string {
+	// Create the temporary directory.
+	tmp, err := os.MkdirTemp("", "")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Register a cleanup function on the benchmark to clean up the temporary directory.
+	b.Cleanup(func() {
+		if err := os.RemoveAll(tmp); err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	// Copy the filesystem to the temporary directory.
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, _ error) error {
+		// Get the path info (contains permissions, etc.)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		// Calculate the target path in the temporary directory.
+		targetPath := filepath.Join(tmp, path)
+
+		// If the path is a directory, create it.
+		if d.IsDir() {
+			if err := os.MkdirAll(targetPath, info.Mode()); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// If the path is a file, open it for reading.
+		readFile, err := fsys.Open(path)
+		if err != nil {
+			return err
+		}
+		defer readFile.Close()
+
+		// Open a new file in the temporary directory for writing.
+		writeFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer writeFile.Close()
+
+		// Copy the file.
+		if _, err := io.Copy(writeFile, readFile); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	return tmp
+}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: deep-01
+version: 0.1.0
+dependencies:
+  - name: level-3-a
+    version: 0.1.0
+  - name: level-3-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-a
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-b
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/charts/level-3-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-01/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-01/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: deep-02
+version: 0.1.0
+dependencies:
+  - name: level-3-a
+    version: 0.1.0
+  - name: level-3-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-a
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-b
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/charts/level-3-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-02/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-02/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: deep-03
+version: 0.1.0
+dependencies:
+  - name: level-3-a
+    version: 0.1.0
+  - name: level-3-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-a
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-b
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/charts/level-3-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-03/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-03/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: deep-04
+version: 0.1.0
+dependencies:
+  - name: level-3-a
+    version: 0.1.0
+  - name: level-3-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-a
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-3-b
+version: 0.1.0
+dependencies:
+  - name: level-2-a
+    version: 0.1.0
+  - name: level-2-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-a
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: level-2-b
+version: 0.1.0
+dependencies:
+  - name: level-1-a
+    version: 0.1.0
+  - name: level-1-b
+    version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-a
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-a/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: level-1-b
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/charts/level-1-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/charts/level-2-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/charts/level-3-b/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/deep-04/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/deep-04/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/flat-01/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-01/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: flat-01
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/flat-01/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-01/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/flat-02/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-02/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: flat-02
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/flat-02/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-02/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/flat-03/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-03/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: flat-03
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/flat-03/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-03/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}

--- a/cmd/helm-docs/testdata/benchmark/flat-04/Chart.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-04/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: flat-04
+version: 0.1.0

--- a/cmd/helm-docs/testdata/benchmark/flat-04/values.yaml
+++ b/cmd/helm-docs/testdata/benchmark/flat-04/values.yaml
@@ -1,0 +1,32 @@
+statefulset:
+  image:
+    # -- Image to use for deploying, must support an entrypoint which creates users/databases from appropriate config files
+    repository: jnorwood/postgresq
+    tag: "11"
+
+  # -- Additional volumes to be mounted into the database container
+  extraVolumes:
+    - name: data
+      emptyDir: {}
+
+  # -- Configure the healthcheck for the database
+  livenessProbe:
+    enabled: false
+
+  # -- The labels to be applied to instances of the database
+  podLabels: {}
+
+config:
+  databasesToCreate:
+    # -- default database for storage of database metadata
+    - postgresql
+
+    # -- database for the [hashbash](https://github.com/norwoodj/hashbash) project
+    - hashbash
+
+  usersToCreate:
+    # -- admin user
+    - {name: root, admin: true}
+
+    # -- user with access to the database with the same name
+    - {name: hashbash, readwriteDatabases: [hashbash]}


### PR DESCRIPTION
Out of curiosity while working on #112 , I added this benchmark in order to compare the helm-docs runtime with and without parallel processing and indexing. I figure it might be good to have checked-in. I noticed there was no CONTRIBUTING.md, so I started one in order to document the benchmarks.

To save you time reviewing the new testdata, all of the values.yaml files are identical. 😉 