### PR TITLE
Add option for a values file named other than `values.yaml`.

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -51,6 +51,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")
 	command.PersistentFlags().StringP("sort-values-order", "s", document.AlphaNumSortOrder, fmt.Sprintf("order in which to sort the values table (\"%s\" or \"%s\")", document.AlphaNumSortOrder, document.FileSortOrder))
 	command.PersistentFlags().StringSliceP("template-files", "t", []string{"README.md.gotmpl"}, "gotemplate file paths relative to each chart directory from which documentation will be generated")
+	command.PersistentFlags().StringP("values-file", "f", "values.yaml", "Path to values file")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_DOCS")

--- a/pkg/helm/chart_info.go
+++ b/pkg/helm/chart_info.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -141,7 +142,7 @@ func parseChartRequirementsFile(chartDirectory string, apiVersion string) (Chart
 }
 
 func parseChartValuesFile(chartDirectory string) (yaml.Node, error) {
-	valuesPath := path.Join(chartDirectory, "values.yaml")
+	valuesPath := path.Join(chartDirectory, viper.GetString("values-file"))
 	yamlFileContents, err := getYamlFileContents(valuesPath)
 
 	var values yaml.Node
@@ -154,7 +155,7 @@ func parseChartValuesFile(chartDirectory string) (yaml.Node, error) {
 }
 
 func parseChartValuesFileComments(chartDirectory string) (map[string]ChartValueDescription, error) {
-	valuesPath := path.Join(chartDirectory, "values.yaml")
+	valuesPath := path.Join(chartDirectory, viper.GetString("values-file"))
 	valuesFile, err := os.Open(valuesPath)
 
 	if isErrorInReadingNecessaryFile(valuesPath, err) {


### PR DESCRIPTION
Not all values files are named `values.yaml` so it would be handy to be able to point `helm-docs` to the actual values file if it is not named according to the expected convention. Many tools, including `helm` itself, support a `-f` short option to which you can supply a relative filesystem path that refers to the values file you'd like to load. This change set makes `helm-docs` support that same CLI interface.