### PR TITLE
Escape `|` in comments, conditionally in default values

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -46,6 +46,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	logLevelUsage := fmt.Sprintf("Level of logs that should printed, one of (%s)", strings.Join(possibleLogLevels(), ", "))
 	command.PersistentFlags().StringP("chart-search-root", "c", ".", "directory to search recursively within for charts")
 	command.PersistentFlags().BoolP("dry-run", "d", false, "don't actually render any markdown files just print to stdout passed")
+	command.PersistentFlags().BoolP("escape-values-pipes", "e", false, "escape pipes in the default values for rendering in certain markdown engines")
 	command.PersistentFlags().StringP("ignore-file", "i", ".helmdocsignore", "The filename to use as an ignore file to exclude chart directories")
 	command.PersistentFlags().StringP("log-level", "l", "info", logLevelUsage)
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")

--- a/pkg/document/generate.go
+++ b/pkg/document/generate.go
@@ -29,11 +29,14 @@ func getOutputFile(chartDirectory string, dryRun bool) (*os.File, error) {
 func PrintDocumentation(chartDocumentationInfo helm.ChartDocumentationInfo, chartSearchRoot string, templateFiles []string, dryRun bool, helmDocsVersion string, badgeStyle string, dependencyValues []DependencyValues) {
 	log.Infof("Generating README Documentation for chart %s", chartDocumentationInfo.ChartDirectory)
 
+	escapeValuesPipes := viper.GetBool("escape-values-pipes")
+
 	chartDocumentationTemplate, err := newChartDocumentationTemplate(
 		chartDocumentationInfo,
 		chartSearchRoot,
 		templateFiles,
 		badgeStyle,
+		escapeValuesPipes,
 	)
 
 	if err != nil {

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -203,7 +203,7 @@ func getRequirementsTableTemplates() string {
 	return requirementsSectionBuilder.String()
 }
 
-func getValuesTableTemplates() string {
+func getValuesTableTemplates(escapeValuesPipes bool) string {
 	valuesSectionBuilder := strings.Builder{}
 	valuesSectionBuilder.WriteString(`{{ define "chart.valuesHeader" }}## Values{{ end }}`)
 
@@ -211,7 +211,11 @@ func getValuesTableTemplates() string {
 	valuesSectionBuilder.WriteString("| Key | Type | Default | Description |\n")
 	valuesSectionBuilder.WriteString("|-----|------|---------|-------------|\n")
 	valuesSectionBuilder.WriteString("  {{- range .Values }}")
-	valuesSectionBuilder.WriteString("\n| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |")
+	if escapeValuesPipes {
+		valuesSectionBuilder.WriteString("\n" + `| {{ .Key }} | {{ .Type }} | {{ .Default | replace "|" "\\|" | default .AutoDefault }} | {{ .Description | replace "|" "\\|" | default .AutoDescription }} |`)
+	} else {
+		valuesSectionBuilder.WriteString("\n" + `| {{ .Key }} | {{ .Type }} | {{ .Default | default .AutoDefault }} | {{ .Description | replace "|" "\\|" | default .AutoDescription }} |`)
+	}
 	valuesSectionBuilder.WriteString("  {{- end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 
@@ -282,7 +286,7 @@ func getDocumentationTemplate(chartDirectory string, chartSearchRoot string, tem
 	return string(allTemplateContents), nil
 }
 
-func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, templateFiles []string, badgeStyle string) ([]string, error) {
+func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, templateFiles []string, badgeStyle string, escapeValuesPipes bool) ([]string, error) {
 	documentationTemplate, err := getDocumentationTemplate(chartDirectory, chartSearchRoot, templateFiles)
 
 	if err != nil {
@@ -301,7 +305,7 @@ func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, te
 		getTypeTemplate(badgeStyle),
 		getSourceLinkTemplates(),
 		getRequirementsTableTemplates(),
-		getValuesTableTemplates(),
+		getValuesTableTemplates(escapeValuesPipes),
 		getHomepageTemplate(),
 		getMaintainersTemplate(),
 		getHelmDocsVersionTemplates(),
@@ -309,10 +313,10 @@ func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, te
 	}, nil
 }
 
-func newChartDocumentationTemplate(chartDocumentationInfo helm.ChartDocumentationInfo, chartSearchRoot string, templateFiles []string, badgeStyle string) (*template.Template, error) {
+func newChartDocumentationTemplate(chartDocumentationInfo helm.ChartDocumentationInfo, chartSearchRoot string, templateFiles []string, badgeStyle string, escapeValuesPipes bool) (*template.Template, error) {
 	documentationTemplate := template.New(chartDocumentationInfo.ChartDirectory)
 	documentationTemplate.Funcs(sprig.TxtFuncMap())
-	goTemplateList, err := getDocumentationTemplates(chartDocumentationInfo.ChartDirectory, chartSearchRoot, templateFiles, badgeStyle)
+	goTemplateList, err := getDocumentationTemplates(chartDocumentationInfo.ChartDirectory, chartSearchRoot, templateFiles, badgeStyle, escapeValuesPipes)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Two changes in this PR:

1. Always escapes pipes in the comments for a value. Fixes https://github.com/norwoodj/helm-docs/issues/118
2. Adds a new flag -e or --escape-values-pipes that controls whether pipes are escaped for the default values as printed in the README. This is beneficial for Gitlab in particular since Markdown rendering will break the table when a | occurs in the default values in a chart.

/cc @norwoodj