### PR TITLE
adding ignore-non-descriptions flag

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -46,6 +46,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	logLevelUsage := fmt.Sprintf("Level of logs that should printed, one of (%s)", strings.Join(possibleLogLevels(), ", "))
 	command.PersistentFlags().StringP("chart-search-root", "c", ".", "directory to search recursively within for charts")
 	command.PersistentFlags().BoolP("dry-run", "d", false, "don't actually render any markdown files just print to stdout passed")
+	command.PersistentFlags().Bool("ignore-non-descriptions", false, "ignore values without a comment, this values will not be included in the README")
 	command.PersistentFlags().StringP("ignore-file", "i", ".helmdocsignore", "The filename to use as an ignore file to exclude chart directories")
 	command.PersistentFlags().StringP("log-level", "l", "info", logLevelUsage)
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -97,6 +97,10 @@ func getChartTemplateData(info helm.ChartDocumentationInfo, helmDocsVersion stri
 		return chartTemplateData{}, err
 	}
 
+	if viper.GetBool("ignore-non-descriptions") {
+		valuesTableRows = removeRowsWithoutDescription(valuesTableRows)
+	}
+
 	if len(dependencyValues) > 0 {
 		seenGlobalKeys := make(map[string]bool)
 		for i, row := range valuesTableRows {
@@ -136,4 +140,15 @@ func getChartTemplateData(info helm.ChartDocumentationInfo, helmDocsVersion stri
 		HelmDocsVersion:        helmDocsVersion,
 		Values:                 valuesTableRows,
 	}, nil
+}
+
+func removeRowsWithoutDescription(valuesTableRows []valueRow) []valueRow {
+
+	var valuesTableRowsWithoutDescription []valueRow
+	for i := range valuesTableRows {
+		if valuesTableRows[i].AutoDescription != "" || valuesTableRows[i].Description != "" {
+			valuesTableRowsWithoutDescription = append(valuesTableRowsWithoutDescription, valuesTableRows[i])
+		}
+	}
+	return valuesTableRowsWithoutDescription
 }

--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -127,7 +127,7 @@ func getDescriptionFromNode(node *yaml.Node) helm.ChartValueDescription {
 		return helm.ChartValueDescription{}
 	}
 
-	if !strings.Contains(node.HeadComment, "# --") {
+	if !strings.Contains(node.HeadComment, helm.PrefixComment) {
 		return helm.ChartValueDescription{}
 	}
 	commentLines := strings.Split(node.HeadComment, "\n")

--- a/pkg/helm/comment.go
+++ b/pkg/helm/comment.go
@@ -4,6 +4,10 @@ import (
 	"strings"
 )
 
+const (
+	PrefixComment = "# --"
+)
+
 func ParseComment(commentLines []string) (string, ChartValueDescription) {
 	var valueKey string
 	var c ChartValueDescription
@@ -13,7 +17,7 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 	// the last "group" of comment lines starting with '# --'.
 	lastIndex := 0
 	for i, v := range commentLines {
-		if strings.HasPrefix(v, "# --") {
+		if strings.HasPrefix(v, PrefixComment) {
 			lastIndex = i
 		}
 	}


### PR DESCRIPTION
This way, by adding the `ignore-non-descriptions` flag, values without description will be excluded from the table.
The default will remain as it is now.