### PR TITLE
fix(README): change the way helm-docs is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ go build
 Or install from source:
 
 ```bash
-GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
+go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 ```
 
 ## Usage


### PR DESCRIPTION
In go 1.18 `go get` is no longer a valid way to install packages, see: https://go.dev/doc/go-get-install-deprecation
> In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. Specifically, go get will always act as if the -d flag were enabled.