### PR TITLE
update/fix source install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ go build
 Or install from source:
 
 ```bash
-GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
+GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 ```
 
 ## Usage


### PR DESCRIPTION
```(shell)
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

my following fix is enabling local install without cloning the repository.