### PR TITLE
docs: improving community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: 🐞 Bug Report
+description: File a new bug report
+title: '[Bug]: <title>'
+labels: 
+  - "bug"
+  - "triage"
+assignees:
+  - "norwoodj"
+  - "Nepo26"
+body:
+  - type: markdown
+    attributes:
+      value: 'Thanks for taking the time to fill out this bug report!'
+  - type: checkboxes
+    attributes:
+      label: 'Is there an existing issue for this?'
+      description: 'Please [search :mag: the issues](https://github.com/norwoodj/helm-docs/issues) to check if this bug has already been reported.'
+      options:
+        - label: 'I have searched the existing issues'
+          required: true
+  - type: textarea
+    attributes:
+      label: 'Current Behavior'
+      description: 'Describe the problem you are experiencing.  **Please do not paste your logs here.**  Screenshots are welcome.'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 'Expected Behavior'
+      description: 'Describe what you expect to happen instead.'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 'Reference Chart'
+      description: |
+        Please provide an example chart, be it the full code or just a reference to a repository.
+        
+        > OBS.: :warning: _Remember to redact or remove any sensitive information!_
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 'Reference Template'
+      description: |
+        If you are using a custom template, put it in here, so we can help you better.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: 'Environment'
+      description: 'Please provide the following information about your environment; feel free to remove any items which are not relevant.'
+      value: |
+        - Operating system:
+        - Helm version (output of `helm version`):
+        - GO version (output of `go version`):
+        - Method of calling `helm-docs` (manual, jenkins, github action ...):
+#TODO Add when the version function is implemented:
+# - **helm-docs** version (output of `helm-docs version`):
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: 'Link to `helm-docs` Logs'
+      description: |
+        Create a [Gist](https://gist.github.com)—which contains your _full_ `helm-docs` logs—and link it here.  Alternatively, you can attach a logfile to this issue (drag it into the "Further Information" field below).
+        
+        Remember to use the following flag `--log-level debug`
+        
+        > OBS.: :warning: _Remember to redact or remove any sensitive information!_
+      placeholder: 'https://gist.github.com/...'
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Further Information
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        _Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in._
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: ':stop_sign: _For support questions, you may create an issue with the question template._'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+blank_issues_enabled: false
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feat]: <title>"
+labels: 
+  - enhancement
+assignees: 
+  - Nepo26
+
+---
+<!--- Provide a general summary of the issue in the Title above -->
+
+
+## Is your feature request related to a problem? Please describe and/or link to a bug issue
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Expected Behavior
+<!--- Tell us how it should work -->
+
+## Current Behavior
+<!--- Explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Ideas on how to implement the addition or change -->
+
+## Describe alternatives you've considered
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+<!--- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,61 @@
+name: 🌟 Feature Request
+description: Suggest an idea for this project
+title: "[Feat]: <title>"
+labels:
+  - "enhancement"
+  - "triage"
+assignees:
+  - "norwoodj"
+  - "Nepo26"
+body:
+  - type: markdown
+    attributes:
+      value: "Thank you for the interest in the project! :blush:"
+  - type: textarea
+    attributes:
+      label: "General Summary"
+      description: "Provide a general summary of the issue in the Title above"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Is your feature request related to a problem? Please describe and/or link to a bug issue."
+      description: "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Expected Behavior"
+      description: "Tell us how it should work"
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: "Current Behavior"
+      description: "Explain the difference from current behavior"
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: "Possible Solution"
+      description: "Ideas on how to implement the addition or change"
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: "Alternatives you've considered"
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Further Information
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+        
+        - How has this issue affected you? What are you trying to accomplish?
+        - Providing context helps us come up with a solution that is most useful in the real world
+        
+        _Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in._
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE/general_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general_template.md
@@ -1,0 +1,27 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce to `helm-docs`?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/PULL_REQUEST_TEMPLATE/general_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general_template.md
@@ -16,7 +16,7 @@ _Put an `x` in the boxes that apply_
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
+- [ ] I have read the [CONTRIBUTING](https://github.com/norwoodj/helm-docs/blob/master/CONTRIBUTING.md) doc
 - [ ] Lint and unit tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,19 @@
 # Contributing to helm-docs
 
+## Build
+To build from source in this repository:
+
+```bash
+cd cmd/helm-docs
+go build
+```
+
+Or you can install from source:
+
+```bash
+GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
+```
+
 ## Testing
 
 ### Benchmarks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+## Security
+
+We take this project and its users security seriously.
+
+If you believe you have found a security vulnerability in any part of this repo,
+please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them in the [private vulnerability reporting](https://github.com/norwoodj/helm-docs/security/advisories).
+
+If you prefer to submit without logging in, send email to [norwood.john.m@gmail.com](mailto:norwood.john.m@gmail.com) or
+[nepo26.hn@gmail.com](mailto:nepo26.hn@gmail.com).  
+
+[//]: # ( If possible, encrypt your message with our PGP key )
+[//]: # (TODO Create a public PGP key and make it available for anyone that needs it )
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to
+ensure we received your original message.
+
+Please include the requested information listed below (as much as you can provide) to help us better 
+understand the nature and scope of the possible issue:
+
+* Type of issue (e.g. buffer overflow, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,135 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at 
+[norwood.john.m@gmail.com](mailto:norwood.john.m@gmail.com) or
+[nepo26.hn@gmail.com](mailto:nepo26.hn@gmail.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+


### PR DESCRIPTION
> **OBS.: Unfornately the commit message pushed wasn't correct, sorry about that. Reference the following text as a possible substitute.**
# Improving Community Guidelines
Making simple changes to make contributing to the project better and easier.

- Refining guidelines for _contribution_ and defining _security reports_ and the repository _code of conduct_.
- Creating issue templates for **bugs** and **feature** requests.
- Creating a general template for **pull requests**.

## What did I use as reference?
I used the following resources and projects:

### Websites
- https://opensource.guide/
- https://www.talater.com/open-source-templates/#/page/1

### Repo References
- https://github.com/stevemao/github-issue-templates
- https://github.com/devspace/awesome-github-templates
- https://raw.githubusercontent.com/microsoft/.github/main/SECURITY.md
- https://github.com/appium/appium/

### GitHub Docs
- https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/about-coordinated-disclosure-of-security-vulnerabilities#about-reporting-and-disclosing-vulnerabilities-in-projects-on-github
- https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys

