### PR TITLE
chore: set go version to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/norwoodj/helm-docs
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2


### PR DESCRIPTION
Very minor, but on macos M1, I got this issue https://github.com/golang/go/issues/65568

```
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```