### PR TITLE
feat: support section description through user-defined templates

### DIFF
--- a/example-charts/sections-description/Chart.yaml
+++ b/example-charts/sections-description/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: sections-description
+version: "1.0.0"
+type: application
+appVersion: "13.0.0"
+description: A chart for showing how to use sections with description
+home: "https://github.com/norwoodj/helm-docs/tree/master/example-charts/sections-description"
+maintainers:
+  - email: pa.koutsovasilis@gmail.com
+    name: Panos Koutsovasilis
+sources: ["https://github.com/norwoodj/helm-docs/tree/master/example-charts/sections-description"]
+engine: gotpl

--- a/example-charts/sections-description/README.md
+++ b/example-charts/sections-description/README.md
@@ -5,13 +5,14 @@ This creates values, but sectioned into own section tables if a section comment 
 ## Values
 
 ### Some Section
-Some Section description
+Some Section description PreTable
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | controller.extraVolumes[0].configMap.name | string | `"nginx-ingress-config"` | Uses the name of the configmap created by this chart |
 | controller.persistentVolumeClaims | list | the chart will construct this list internally unless specified | List of persistent volume claims to create. |
 | controller.podLabels | object | `{}` | The labels to be applied to instances of the controller pod |
+Some Section description PostTable
 
 ### Special Attention
 Special Attention description

--- a/example-charts/sections-description/README.md
+++ b/example-charts/sections-description/README.md
@@ -1,0 +1,29 @@
+# Sections
+
+This creates values, but sectioned into own section tables if a section comment is provided.
+
+## Values
+
+### Some Section
+Some Section description
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.extraVolumes[0].configMap.name | string | `"nginx-ingress-config"` | Uses the name of the configmap created by this chart |
+| controller.persistentVolumeClaims | list | the chart will construct this list internally unless specified | List of persistent volume claims to create. |
+| controller.podLabels | object | `{}` | The labels to be applied to instances of the controller pod |
+
+### Special Attention
+Special Attention description
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.ingressClass | string | `"nginx"` | You can also specify value comments like this |
+| controller.publishService | object | `{"enabled":false}` | This is a publishService |
+| controller.replicas | int | `nil` | Number of nginx-ingress pods to load balance between |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" | string | `"stupidchess.jmn23.com"` | Hostname to be assigned to the ELB for the service |

--- a/example-charts/sections-description/README.md.gotmpl
+++ b/example-charts/sections-description/README.md.gotmpl
@@ -2,8 +2,12 @@
 
 This creates values, but sectioned into own section tables if a section comment is provided.
 
-{{ define "section.description.SomeSection" }}
-Some Section description
+{{ define "section.description.SomeSection.PreTable" }}
+Some Section description PreTable
+{{ end }}
+
+{{ define "section.description.SomeSection.PostTable" }}
+Some Section description PostTable
 {{ end }}
 
 

--- a/example-charts/sections-description/README.md.gotmpl
+++ b/example-charts/sections-description/README.md.gotmpl
@@ -1,0 +1,14 @@
+# Sections
+
+This creates values, but sectioned into own section tables if a section comment is provided.
+
+{{ define "section.description.SomeSection" }}
+Some Section description
+{{ end }}
+
+
+{{ define "section.description.SpecialAttention" }}
+Special Attention description
+{{ end }}
+
+{{ template "chart.valuesSection" . }}

--- a/example-charts/sections-description/values.yaml
+++ b/example-charts/sections-description/values.yaml
@@ -1,0 +1,45 @@
+controller:
+  name: controller
+  image:
+    repository: nginx-ingress-controller
+    tag: "18.0831"
+
+  # controller.persistentVolumeClaims -- List of persistent volume claims to create.
+  # @default -- the chart will construct this list internally unless specified
+  # @section -- Some Section
+  # @sectionDescriptionTemplate -- SomeSection
+  persistentVolumeClaims: []
+
+  extraVolumes:
+    - name: config-volume
+      configMap:
+        # controller.extraVolumes[0].configMap.name -- Uses the name of the configmap created by this chart
+        # @section -- Some Section
+        name: nginx-ingress-config
+
+  # -- You can also specify value comments like this
+  # @section -- Special Attention
+  # @sectionDescriptionTemplate -- SpecialAttention
+  ingressClass: nginx
+
+
+  # controller.podLabels -- The labels to be applied to instances of the controller pod
+  # @section -- Some Section
+  podLabels: {}
+
+  # controller.publishService -- This is a publishService
+  # @section -- Special Attention
+  publishService:
+    enabled: false
+
+  # -- (int) Number of nginx-ingress pods to load balance between
+  # @raw
+  # @section -- Special Attention
+  replicas:
+
+  service:
+    annotations:
+      # controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" -- Hostname to be assigned to the ELB for the service
+      external-dns.alpha.kubernetes.io/hostname: stupidchess.jmn23.com
+
+    type: LoadBalancer

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -13,18 +13,19 @@ import (
 )
 
 type valueRow struct {
-	Key             string
-	Type            string
-	NotationType    string
-	AutoDefault     string
-	Default         string
-	AutoDescription string
-	Description     string
-	Section         string
-	Column          int
-	LineNumber      int
-	Dependency      string
-	IsGlobal        bool
+	Key                        string
+	Type                       string
+	NotationType               string
+	AutoDefault                string
+	Default                    string
+	AutoDescription            string
+	Description                string
+	Section                    string
+	SectionDescriptionTemplate string
+	Column                     int
+	LineNumber                 int
+	Dependency                 string
+	IsGlobal                   bool
 }
 
 type chartTemplateData struct {
@@ -41,8 +42,9 @@ type sections struct {
 }
 
 type section struct {
-	SectionName  string
-	SectionItems []valueRow
+	SectionName                 string
+	SectionDescriptionTemplates []string
+	SectionItems                []valueRow
 }
 
 func sortValueRowsByOrder(valueRows []valueRow, sortOrder string) {
@@ -130,6 +132,8 @@ func getSectionedValueRows(valueRows []valueRow) sections {
 		SectionItems: []valueRow{},
 	}
 
+	sectionDescriptionTemplatesMap := make(map[string][]string)
+
 	for _, row := range valueRows {
 		if row.Section == "" {
 			valueRowsSectionSorted.DefaultSection.SectionItems = append(valueRowsSectionSorted.DefaultSection.SectionItems, row)
@@ -151,6 +155,19 @@ func getSectionedValueRows(valueRows []valueRow) sections {
 				SectionItems: []valueRow{row},
 			})
 		}
+
+		if row.SectionDescriptionTemplate != "" {
+			sectionDescriptionTemplatesMap[row.Section] = append(sectionDescriptionTemplatesMap[row.Section], row.SectionDescriptionTemplate)
+		}
+	}
+
+	for i, section := range valueRowsSectionSorted.Sections {
+		sectionDescriptionTemplates, exists := sectionDescriptionTemplatesMap[section.SectionName]
+		if !exists {
+			continue
+		}
+
+		valueRowsSectionSorted.Sections[i].SectionDescriptionTemplates = sectionDescriptionTemplates
 	}
 
 	return valueRowsSectionSorted

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -274,7 +274,9 @@ func getValuesTableTemplates() string {
 {{ if .Sections.Sections }}
 {{- range .Sections.Sections }}
 <h3>{{- .SectionName }}</h3>
-<p>{{- sectionDescriptionTemplate .sectionDescriptionTemplate }}</p>
+{{- range .SectionDescriptionTemplates }}
+<p>{{- sectionDescriptionTemplate . }}</p>
+{{- end }}
 <table>
 	<thead>
 		<th>Key</th>

--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -191,17 +191,23 @@ func createValueRow(
 		section = autoDescription.Section
 	}
 
+	sectionDescriptionTemplate := description.SectionDescriptionTemplate
+	if sectionDescriptionTemplate == "" && autoDescription.SectionDescriptionTemplate != "" {
+		sectionDescriptionTemplate = autoDescription.SectionDescriptionTemplate
+	}
+
 	return valueRow{
-		Key:             key,
-		Type:            defaultType,
-		NotationType:    notationType,
-		AutoDefault:     autoDescription.Default,
-		Default:         defaultValue,
-		AutoDescription: autoDescription.Description,
-		Description:     description.Description,
-		Section:         section,
-		Column:          column,
-		LineNumber:      lineNumber,
+		Key:                        key,
+		Type:                       defaultType,
+		NotationType:               notationType,
+		AutoDefault:                autoDescription.Default,
+		Default:                    defaultValue,
+		AutoDescription:            autoDescription.Description,
+		Description:                description.Description,
+		Section:                    section,
+		SectionDescriptionTemplate: sectionDescriptionTemplate,
+		Column:                     column,
+		LineNumber:                 lineNumber,
 	}, nil
 }
 

--- a/pkg/helm/chart_info.go
+++ b/pkg/helm/chart_info.go
@@ -22,6 +22,7 @@ var defaultValueRegex = regexp.MustCompile("^\\s*# @default -- (.*)$")
 var valueTypeRegex = regexp.MustCompile("^\\((.*?)\\)\\s*(.*)$")
 var valueNotationTypeRegex = regexp.MustCompile("^\\s*#\\s+@notationType\\s+--\\s+(.*)$")
 var sectionRegex = regexp.MustCompile("^\\s*# @section -- (.*)$")
+var sectionDescriptionTemplateRegex = regexp.MustCompile("^\\s*# @sectionDescriptionTemplate -- (.*)$")
 
 type ChartMetaMaintainer struct {
 	Email string
@@ -56,11 +57,12 @@ type ChartRequirements struct {
 }
 
 type ChartValueDescription struct {
-	Description  string
-	Default      string
-	Section      string
-	ValueType    string
-	NotationType string
+	Description                string
+	Default                    string
+	Section                    string
+	SectionDescriptionTemplate string
+	ValueType                  string
+	NotationType               string
 }
 
 type ChartDocumentationInfo struct {

--- a/pkg/helm/comment.go
+++ b/pkg/helm/comment.go
@@ -51,6 +51,7 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 		defaultCommentMatch := defaultValueRegex.FindStringSubmatch(line)
 		notationTypeCommentMatch := valueNotationTypeRegex.FindStringSubmatch(line)
 		sectionCommentMatch := sectionRegex.FindStringSubmatch(line)
+		sectionDescriptionTemplateMatch := sectionDescriptionTemplateRegex.FindStringSubmatch(line)
 
 		if !isRaw && len(rawFlagMatch) == 1 {
 			isRaw = true
@@ -69,6 +70,11 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 
 		if len(sectionCommentMatch) > 1 {
 			c.Section = sectionCommentMatch[1]
+			continue
+		}
+
+		if len(sectionDescriptionTemplateMatch) > 1 {
+			c.SectionDescriptionTemplate = sectionDescriptionTemplateMatch[1]
 			continue
 		}
 


### PR DESCRIPTION
This PR is a PoC of how user-defined templates could be incorporated to support writing a description between the Section header and values table.

An example of this can be found [here](https://github.com/pkoutsovasilis/helm-docs/tree/feat/section_descriptions/example-charts/sections-description)

- Relates https://github.com/norwoodj/helm-docs/issues/227