### PR TITLE
chore: bump to use go1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/norwoodj/helm-docs
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/176552