### PR TITLE
fix: restore support for ignored yaml comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,24 @@ configMap:
   not real config param: value
 ```
 
+### Ignored YAML comments 
+
+In cases you would like to not include certain YAML comments, such as explicit example, context information, you me use a double `#` to tell helm-docs to ignore e.g.
+
+```yaml
+  # -- Using existing secret
+  ## Secret format:
+  ##  stringData:
+  ##    comm_config.yaml: |
+  ##      communications:
+  ##        # Here specify settings for each app, like Slack, Mattermost etc.
+  ##        # NOTE: Use setting format visible below.
+  ##
+  ## FIXME some keys needs stuff to happen. See #1234
+  # @default -- an empty string, meaning no existing secret
+  existingSecretName: ""
+```
+
 ### Advanced table rendering
 Some helm chart `values.yaml` uses complicated structure for the key/value
 pairs. For example, it may uses a multiline string of Go template text instead

--- a/example-charts/comment-ignored/Chart.yaml
+++ b/example-charts/comment-ignored/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: comment-ignored
+description: A simple chart that installs, let's say PrometheusRules, that contains values.yaml comment that shouldn't be included in the helm-docs
+version: "0.2.0"
+home: "https://github.com/norwoodj/helm-docs/tree/master/example-charts/comment-ignored"
+sources: ["https://github.com/norwoodj/helm-docs/tree/master/example-charts/comment-ignored"]
+engine: gotpl
+maintainers:
+  - email: norwood.john.m@gmail.com
+    name: John Norwood

--- a/example-charts/comment-ignored/README.md
+++ b/example-charts/comment-ignored/README.md
@@ -1,10 +1,10 @@
-# comment-ignored
+# no-requirements
 
 ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 
 A simple chart that installs, let's say PrometheusRules, that needs no sub-charts
 
-**Homepage:** <https://github.com/norwoodj/helm-docs/tree/master/example-charts/comment-ignored>
+**Homepage:** <https://github.com/norwoodj/helm-docs/tree/master/example-charts/no-requirements>
 
 ## Maintainers
 
@@ -14,7 +14,7 @@ A simple chart that installs, let's say PrometheusRules, that needs no sub-chart
 
 ## Source Code
 
-* <https://github.com/norwoodj/helm-docs/tree/master/example-charts/comment-ignored>
+* <https://github.com/norwoodj/helm-docs/tree/master/example-charts/no-requirements>
 
 ## Values
 

--- a/example-charts/comment-ignored/values.yaml
+++ b/example-charts/comment-ignored/values.yaml
@@ -1,0 +1,15 @@
+rules:
+  latency:
+    percentiles:
+      "99":
+        # rules.latency.percentiles.99.threshold -- Threshold in seconds for our 99th percentile latency above which the alert will fire
+        ## Note that this is a secret comment that should be added to the doc
+        threshold: 1.5
+        # rules.latency.percentiles.99.duration -- Duration for which the 99th percentile must be above the threshold to alert
+        ## Secret format:
+        ##  stringData:
+        ##    comm_config.yaml: |
+        ##      communications:
+        ##        # Here specify settings for each app, like Slack, Mattermost etc.
+        ##        # NOTE: Use setting format visible below.
+        duration: 5m

--- a/pkg/helm/comment.go
+++ b/pkg/helm/comment.go
@@ -74,6 +74,11 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 
 		commentContinuationMatch := commentContinuationRegex.FindStringSubmatch(line)
 
+		// If the comment uses a double hash, this means it should be ignored for the documentation
+		if len(line) > 2 && line[1] == '#' {
+			continue
+		}
+
 		if isRaw {
 
 			if len(commentContinuationMatch) > 1 {


### PR DESCRIPTION
Fixes #148 

Note that a negative lookbehind could also be used on the comment regex, but I'm concerned about the performance impact it may have on large value files, so I opted for a `0(1)` solution.