### PR TITLE
feat: trim whitespaces before header

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -15,7 +15,7 @@ import (
 	"github.com/norwoodj/helm-docs/pkg/helm"
 )
 
-const defaultDocumentationTemplate = `{{ template "chart.header" . }}
+const defaultDocumentationTemplate = `{{- template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}


### PR DESCRIPTION
### Description

- Without it, the Markdown header is being created after a newline.