### PR TITLE
fix: display correct output file on error

### DIFF
--- a/pkg/document/generate.go
+++ b/pkg/document/generate.go
@@ -49,7 +49,7 @@ func PrintDocumentation(chartDocumentationInfo helm.ChartDocumentationInfo, char
 
 	outputFile, err := getOutputFile(chartDocumentationInfo.ChartDirectory, dryRun)
 	if err != nil {
-		log.Warnf("Could not open chart README file %s, skipping chart", filepath.Join(chartDocumentationInfo.ChartDirectory, "README.md"))
+		log.Warnf("Could not open chart README file %s, skipping chart", filepath.Join(chartDocumentationInfo.ChartDirectory, viper.GetString("output-file"))
 		return
 	}
 


### PR DESCRIPTION
When there's an error opening the output file, report the correct filename.