### PR TITLE
fix: replace `Url` with `URL`

### DIFF
--- a/example-charts/best-values-example/README.md
+++ b/example-charts/best-values-example/README.md
@@ -8,7 +8,7 @@ One of the best values parsing example charts here, exhibits several more compli
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/custom-value-notation-type/README.md
+++ b/example-charts/custom-value-notation-type/README.md
@@ -8,7 +8,7 @@ Generic chart for basic Django-based web app
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | Rizky Maulana Nugraha | <lana.pcfre@gmail.com> |  |
 

--- a/example-charts/full-template/README.md
+++ b/example-charts/full-template/README.md
@@ -68,7 +68,7 @@ https://github.com/norwoodj/helm-docs/tree/master/example-charts/full-template
 
 ## `chart.maintainersTable`
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 
@@ -76,7 +76,7 @@ https://github.com/norwoodj/helm-docs/tree/master/example-charts/full-template
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/fully-documented/README.md
+++ b/example-charts/fully-documented/README.md
@@ -8,7 +8,7 @@ A simple wrapper around the stable/nginx-ingress chart that adds a few of our co
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/funky-version/README.md
+++ b/example-charts/funky-version/README.md
@@ -8,7 +8,7 @@ A very simple chart with a funky version
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/helm-3/README.md
+++ b/example-charts/helm-3/README.md
@@ -8,7 +8,7 @@ A simple wrapper around the stable/nginx-ingress chart that adds a few of our co
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/ignored-values-example/README.md
+++ b/example-charts/ignored-values-example/README.md
@@ -8,7 +8,7 @@ Based on best-values-example
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | Jakub Buczak | <jakub.buczak@gmail.com> |  |
 

--- a/example-charts/nginx-ingress-but-auto-comments/README.md
+++ b/example-charts/nginx-ingress-but-auto-comments/README.md
@@ -8,7 +8,7 @@ A simple wrapper around the stable/nginx-ingress chart that adds a few of our co
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/nginx-ingress/README.md
+++ b/example-charts/nginx-ingress/README.md
@@ -8,7 +8,7 @@ A simple wrapper around the stable/nginx-ingress chart that adds a few of our co
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/no-requirements/README.md
+++ b/example-charts/no-requirements/README.md
@@ -8,7 +8,7 @@ A simple chart that installs, let's say PrometheusRules, that needs no sub-chart
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/no-values/README.md
+++ b/example-charts/no-values/README.md
@@ -8,7 +8,7 @@ A very simple chart that doesn't even need any values for customization
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/special-characters-but-auto-comments/README.md
+++ b/example-charts/special-characters-but-auto-comments/README.md
@@ -8,7 +8,7 @@ A chart demonstrating handling of special characters in values files
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/example-charts/special-characters/README.md
+++ b/example-charts/special-characters/README.md
@@ -8,7 +8,7 @@ A chart demonstrating handling of special characters in values files
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -127,7 +127,7 @@ func getMaintainersTemplate() string {
 	maintainerBuilder.WriteString(`{{ define "chart.maintainersHeader" }}## Maintainers{{ end }}`)
 
 	maintainerBuilder.WriteString(`{{ define "chart.maintainersTable" }}`)
-	maintainerBuilder.WriteString("| Name | Email | Url |\n")
+	maintainerBuilder.WriteString("| Name | Email | URL |\n")
 	maintainerBuilder.WriteString("| ---- | ------ | --- |\n")
 	maintainerBuilder.WriteString("  {{- range .Maintainers }}")
 	maintainerBuilder.WriteString("\n| {{ .Name }} | {{ if .Email }}<{{ .Email }}>{{ end }} | {{ if .Url }}<{{ .Url }}>{{ end }} |")

--- a/pkg/helm/test-fixtures/full-template/README.md
+++ b/pkg/helm/test-fixtures/full-template/README.md
@@ -68,7 +68,7 @@ https://github.com/norwoodj/helm-docs/tree/master/example-charts/full-template
 
 ## `chart.maintainersTable`
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 
@@ -76,7 +76,7 @@ https://github.com/norwoodj/helm-docs/tree/master/example-charts/full-template
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 

--- a/pkg/helm/test-fixtures/fully-documented/README.md
+++ b/pkg/helm/test-fixtures/fully-documented/README.md
@@ -8,7 +8,7 @@ A simple wrapper around the stable/nginx-ingress chart that adds a few of our co
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | John Norwood | <norwood.john.m@gmail.com> |  |
 
@@ -31,4 +31,3 @@ A simple wrapper around the stable/nginx-ingress chart that adds a few of our co
 | controller.image.repository | string | `"nginx-ingress-controller"` | The repository of the controller |
 | controller.image.tag | string | `"18.0831"` | The tag of the image of the controller |
 | controller.name | string | `"controller"` | The name of the controller |
-


### PR DESCRIPTION
I start using [textlint](https://github.com/textlint/textlint) in my project and mention that is mark Url as incorrect term.

> ✓ error  Incorrect term: “Url”, use “URL” instead          terminology