### PR TITLE
Add helm plugin.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 *.iml
 .vscode/
 vendor/
+bin/
+releases/

--- a/install_plugin.sh
+++ b/install_plugin.sh
@@ -1,0 +1,53 @@
+#!/bin/sh -e
+
+# Copied w/ love from the excellent hypnoglow/helm-s3
+
+version="$(cat plugin.yaml | grep "version" | cut -d '"' -f 2)"
+echo "Downloading and installing helm-docs v${version} ..."
+
+url=""
+
+arch=""
+case $(uname -m) in
+  x86_64)
+    arch="x86_64"
+    ;;
+  armv6*)
+    arch="arm6"
+    ;;
+  # match every arm processor version like armv7h, armv7l and so on.
+  armv7*)
+    arch="arm7"
+    ;;
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  *)
+    echo "Failed to detect target architecture"
+    exit 1
+    ;;
+esac
+
+
+if [ "$(uname)" = "Darwin" ]; then
+    url="https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Darwin_${arch}.tar.gz"
+elif [ "$(uname)" = "Linux" ] ; then
+    url="https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Linux_${arch}.tar.gz"
+else
+    url="https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Windows_${arch}.tar.gz"
+fi
+
+echo $url
+
+mkdir -p "bin"
+mkdir -p "releases/v${version}"
+
+# Download with curl if possible.
+if [ -x "$(which curl 2>/dev/null)" ]; then
+    curl -sSL "${url}" -o "releases/v${version}.tar.gz"
+else
+    wget -q "${url}" -O "releases/v${version}.tar.gz"
+fi
+tar xzf "releases/v${version}.tar.gz" -C "releases/v${version}"
+mv "releases/v${version}/helm-docs" "bin/helm-chart-docs" || \
+    mv "releases/v${version}/helm-docs.exe" "bin/helm-chart-docs"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,9 @@
+name: "chart-docs"
+version: "1.14.2"
+usage: "Please see https://github.com/norwoodj/helm-docs for usage"
+description: "A tool for automatically generating markdown documentation for helm charts"
+useTunnel: false
+command: "$HELM_PLUGIN_DIR/bin/helm-chart-docs"
+hooks:
+  install: "cd $HELM_PLUGIN_DIR; ./install_plugin.sh"
+  update: "cd $HELM_PLUGIN_DIR; ./install_plugin.sh"


### PR DESCRIPTION
Hello,
this PR will allow to install this plugin with command:
```
helm plugin install https://github.com/norwoodj/helm-docs
```

Because `helm docs` is reserved, I called it `helm chart-docs` to be precise that this is not about helm documentation per se (as `helm docs` command does), but helm chart docs.

Hope you will like it! :)