### PR TITLE
Parse one file at a time to allow templates to overwrite blocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,6 @@ repos:
           # Repeating the flag adds this to the list, now [./_templates.gotmpl, README.md.gotmpl]
           # A base filename makes it relative to each chart directory found
           - --template-files=README.md.gotmpl
+
+          # Allows a file in the directory to override a block defined in an earlier-defined file
+          - --template-files=override.md.gotmpl

--- a/example-charts/override-block/Chart.yaml
+++ b/example-charts/override-block/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+name: most-empty
+version: "0.2.0"
+engine: gotpl
+maintainers:
+  - email: norwood.john.m@gmail.com
+    name: John Norwood

--- a/example-charts/override-block/README.md
+++ b/example-charts/override-block/README.md
@@ -1,0 +1,8 @@
+# most-empty
+
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
+
+The following content will be overwritten by the `extra.overwritten` block in `override.md.gotmpl`:
+
+This is the new content that will replace the original block content.
+

--- a/example-charts/override-block/README.md.gotmpl
+++ b/example-charts/override-block/README.md.gotmpl
@@ -1,0 +1,18 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" .  }}{{ template "chart.typeBadge" .  }}{{ template "chart.appVersionBadge" .  }}
+
+The following content will be overwritten by the `extra.overwritten` block in `override.md.gotmpl`:
+
+{{ block "extra.overwritten" . }}
+
+You'll never see this text ;)
+
+{{- end }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/example-charts/override-block/override.md.gotmpl
+++ b/example-charts/override-block/override.md.gotmpl
@@ -1,0 +1,5 @@
+{{ define "extra.overwritten" -}}
+
+This is the new content that will replace the original block content.
+
+{{- end }}

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -387,13 +387,13 @@ func getDocumentationTemplate(chartDirectory string, chartSearchRoot string, tem
 	for _, templateFileForChart := range templateFilesForChart {
 		templateContents, err := ioutil.ReadFile(templateFileForChart)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		allTemplateContents = append(allTemplateContents, string(templateContents))
 	}
 
 	if templateNotFound {
-		allTemplateContents = append(allTemplateContents, []byte(defaultDocumentationTemplate)...)
+		allTemplateContents = append(allTemplateContents, defaultDocumentationTemplate)
 	}
 
 	return allTemplateContents, nil

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -356,7 +356,7 @@ func getHelmDocsVersionTemplates() string {
 	return versionSectionBuilder.String()
 }
 
-func getDocumentationTemplate(chartDirectory string, chartSearchRoot string, templateFiles []string) (string, error) {
+func getDocumentationTemplate(chartDirectory string, chartSearchRoot string, templateFiles []string) ([]string, error) {
 	templateFilesForChart := make([]string, 0)
 
 	var templateNotFound bool
@@ -383,20 +383,20 @@ func getDocumentationTemplate(chartDirectory string, chartSearchRoot string, tem
 	}
 
 	log.Debugf("Using template files %s for chart %s", templateFiles, chartDirectory)
-	allTemplateContents := make([]byte, 0)
+	allTemplateContents := make([]string, 0)
 	for _, templateFileForChart := range templateFilesForChart {
 		templateContents, err := ioutil.ReadFile(templateFileForChart)
 		if err != nil {
 			return "", err
 		}
-		allTemplateContents = append(allTemplateContents, templateContents...)
+		allTemplateContents = append(allTemplateContents, string(templateContents))
 	}
 
 	if templateNotFound {
 		allTemplateContents = append(allTemplateContents, []byte(defaultDocumentationTemplate)...)
 	}
 
-	return string(allTemplateContents), nil
+	return allTemplateContents, nil
 }
 
 func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, templateFiles []string, badgeStyle string) ([]string, error) {
@@ -407,23 +407,24 @@ func getDocumentationTemplates(chartDirectory string, chartSearchRoot string, te
 		return nil, err
 	}
 
-	return []string{
-		getNameTemplate(),
-		getHeaderTemplate(),
-		getDeprecatedTemplate(),
-		getAppVersionTemplate(badgeStyle),
-		getBadgesTemplates(),
-		getDescriptionTemplate(),
-		getVersionTemplates(badgeStyle),
-		getTypeTemplate(badgeStyle),
-		getSourceLinkTemplates(),
-		getRequirementsTableTemplates(),
-		getValuesTableTemplates(),
-		getHomepageTemplate(),
-		getMaintainersTemplate(),
-		getHelmDocsVersionTemplates(),
-		documentationTemplate,
-	}, nil
+	return append([]string{
+			getNameTemplate(),
+			getHeaderTemplate(),
+			getDeprecatedTemplate(),
+			getAppVersionTemplate(badgeStyle),
+			getBadgesTemplates(),
+			getDescriptionTemplate(),
+			getVersionTemplates(badgeStyle),
+			getTypeTemplate(badgeStyle),
+			getSourceLinkTemplates(),
+			getRequirementsTableTemplates(),
+			getValuesTableTemplates(),
+			getHomepageTemplate(),
+			getMaintainersTemplate(),
+			getHelmDocsVersionTemplates(),
+		},
+		documentationTemplate...
+	), nil
 }
 
 func newChartDocumentationTemplate(chartDocumentationInfo helm.ChartDocumentationInfo, chartSearchRoot string, templateFiles []string, badgeStyle string) (*template.Template, error) {


### PR DESCRIPTION
This fixes the compilation errors in #276 and allows `define` to correctly override `block` when encountered in a later template.

I also added an example of the functionality.

By extension, this also fixes #277.