### PR TITLE
Adding a flag to override version in charts

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -11,6 +11,17 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	versionsOverrideFlagDescription = `
+		Overrides the versions in the README files with the specified value. 
+		Comma separated, no space. 
+		Uses the format <chart-name>:<version>. 
+		If the chart name or version is not specified, the override will be skipped.
+		If the chart name == "*" (example: "*:1.0.0"), the version will be applied to all charts.
+		For example: mychart:1.0.0,mychart2:2.0.0"
+	`
+)
+
 var version string
 
 func possibleLogLevels() []string {
@@ -60,6 +71,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	command.PersistentFlags().StringSliceP("documentation-strict-ignore-absent", "y", []string{"service.type", "image.repository", "image.tag"}, "A comma separate values which are allowed not to be documented in strict mode")
 	command.PersistentFlags().StringSliceP("documentation-strict-ignore-absent-regex", "z", []string{".*service\\.type", ".*image\\.repository", ".*image\\.tag"}, "A comma separate values which are allowed not to be documented in strict mode")
 	command.PersistentFlags().Bool("skip-version-footer", false, "if true the helm-docs version footer will not be shown in the default README template")
+	command.PersistentFlags().StringSliceP("versions-override", "v", []string{}, versionsOverrideFlagDescription)
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_DOCS")

--- a/cmd/helm-docs/main.go
+++ b/cmd/helm-docs/main.go
@@ -185,6 +185,33 @@ func helmDocs(_ *cobra.Command, _ []string) {
 		log.Fatal(err)
 	}
 
+	versionsOverride := viper.GetStringSlice("versions-override")
+	versionOverridesMap := make(map[string]string)
+
+	for _, override := range versionsOverride {
+		parts := strings.Split(override, ":")
+		if len(parts) == 2 {
+			chartName := parts[0]
+			version := parts[1]
+			if chartName == "" || version == "" {
+				log.Warnf("Skipping version override with empty chartName or empty version.")
+				continue
+			}
+			versionOverridesMap[chartName] = version
+		}
+	}
+
+	if len(versionOverridesMap) > 0 {
+		for _, element := range documentationInfoByChartPath {
+			chartName := element.ChartMeta.Name
+			if version, ok := versionOverridesMap[chartName]; ok {
+				element.ChartMeta.Version = version
+			} else if version, ok := versionOverridesMap["*"]; ok {
+				element.ChartMeta.Version = version
+			}
+		}
+	}
+
 	writeDocumentation(chartSearchRoot, documentationInfoByChartPath, dryRun, parallelism)
 }
 


### PR DESCRIPTION
This is an attempt to add a version override for charts in the helm-docs generated documentation.

The idea is to allow for a version override in a similar way that happens already in helm with the command `helm package --version="1.0.0"`.

This is particularly useful in a CI context and especially for dev versions of the artifacts. Since we want to package the correct helm-docs README within the artifact, the idea is to set the right version in the generated README.
