### PR TITLE
fix: use URL to respect natural language linter (textlint)

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -127,7 +127,7 @@ func getMaintainersTemplate() string {
 	maintainerBuilder.WriteString(`{{ define "chart.maintainersHeader" }}## Maintainers{{ end }}`)
 
 	maintainerBuilder.WriteString(`{{ define "chart.maintainersTable" }}`)
-	maintainerBuilder.WriteString("| Name | Email | Url |\n")
+	maintainerBuilder.WriteString("| Name | Email | URL |\n")
 	maintainerBuilder.WriteString("| ---- | ------ | --- |\n")
 	maintainerBuilder.WriteString("  {{- range .Maintainers }}")
 	maintainerBuilder.WriteString("\n| {{ .Name }} | {{ if .Email }}<{{ .Email }}>{{ end }} | {{ if .Url }}<{{ .Url }}>{{ end }} |")


### PR DESCRIPTION
Fixes `Incorrect term: “Url”, use “URL” instead` lint issue. 
See <https://textlint.org/>.