### PR TITLE
feat: publish images to GHCR and add GHCR hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   release:
     name: Release
@@ -35,6 +39,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Login to GHCR
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG key
         if: ${{ !env.ACT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,6 +83,7 @@ dockers:
       - --platform=linux/amd64
     image_templates:
       - jnorwood/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64
   - goos: linux
     goarch: arm64
     dockerfile: Dockerfile
@@ -91,6 +92,7 @@ dockers:
       - --platform=linux/arm64
     image_templates:
       - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64
   - goos: linux
     goarch: arm
     goarm: 6
@@ -100,6 +102,7 @@ dockers:
       - --platform=linux/arm/v6
     image_templates:
       - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v6
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64v6
   - goos: linux
     goarch: arm
     goarm: 7
@@ -109,6 +112,7 @@ dockers:
       - --platform=linux/arm/v7
     image_templates:
       - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v7
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64v7
 docker_manifests:
 - name_template: jnorwood/{{ .ProjectName }}:{{ .Tag }}
   image_templates:
@@ -122,3 +126,15 @@ docker_manifests:
     - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64
     - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v6
     - jnorwood/{{ .ProjectName }}:{{ .Tag }}-arm64v7
+- name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}
+  image_templates:
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64v6
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64v7
+- name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:latest
+  image_templates:
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64v6
+    - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64v7

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,3 +24,12 @@
   language: docker_image
   name: Helm Docs Container
   require_serial: true
+
+- id: helm-docs-container-github
+  args: []
+  description: Uses the container image from the GHCR of 'helm-docs' to create documentation from the Helm chart's 'values.yaml' file, and inserts the result into a corresponding 'README.md' file.
+  entry: ghcr.io/norwoodj/helm-docs:latest
+  files: (README\.md\.gotmpl|(Chart|requirements|values)\.yaml)$
+  language: docker_image
+  name: Helm Docs Container GHCR
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ repos:
 
 ```
 
+#### `helm-docs-container-github` Uses the container image of `helm-docs` from GHCR
+
+```yaml
+---
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev:  ""
+    hooks:
+      - id: helm-docs-container-github
+        args:
+          # Make the tool search for charts only under the `charts` directory
+          - --chart-search-root=charts
+
+```
+
 #### To pin the `helm-docs` container to a specific tag, follow the example below:
 
 
@@ -188,11 +203,18 @@ for every chart that it finds.
 ### Using docker
 
 You can mount a directory with charts under `/helm-docs` within the container.
+The `helm-docs` container image is published to Docker Hub and GHCR.
 
 Then run:
 
 ```bash
 docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
+```
+
+or:
+
+```bash
+docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) ghcr.io/naviteq/helm-docs:latest
 ```
 
 ## Ignoring Chart Directories


### PR DESCRIPTION
Changes:

- Updates release workflow login permissions in .github/workflows/release.yml
- Publishes multi-arch images to GHCR in .goreleaser.yml
- Add a GHCR-backed pre-commit hook

Motivation: have the fallback to workaround Dockerhub rate limits which can be the real problem for real active usage of this precommit hook in the CI as extra validation step.