### PR TITLE
fix: escape pipe characters in Markdown values table cells

### DIFF
--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -217,11 +217,11 @@ func getValuesTableTemplates() string {
 	valuesSectionBuilder.WriteString("{{ end }}")
 
 	valuesSectionBuilder.WriteString(`{{ define "chart.valueDefaultColumnRenderMd" }}`)
-	valuesSectionBuilder.WriteString("{{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }}")
+	valuesSectionBuilder.WriteString("{{ if .Default }}{{ .Default | escapeMarkdownTableCell }}{{ else }}{{ .AutoDefault | escapeMarkdownTableCell }}{{ end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 
 	valuesSectionBuilder.WriteString(`{{ define "chart.valueDescriptionColumnRenderMd" }}`)
-	valuesSectionBuilder.WriteString("{{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }}")
+	valuesSectionBuilder.WriteString("{{ if .Description }}{{ .Description | escapeMarkdownTableCell }}{{ else }}{{ .AutoDescription | escapeMarkdownTableCell }}{{ end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 
 	valuesSectionBuilder.WriteString(`{{ define "chart.valuesTable" }}`)

--- a/pkg/document/template_test.go
+++ b/pkg/document/template_test.go
@@ -1,8 +1,11 @@
 package document
 
 import (
+	"strings"
 	"testing"
+	"text/template"
 
+	"github.com/norwoodj/helm-docs/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,4 +28,29 @@ func TestGetDocumentationTemplate_LoadDefaultOnNotFound(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, expected, tpl)
+}
+
+func TestValuesTableEscapesPipeInCells(t *testing.T) {
+	tmpl := template.New("test").Funcs(util.FuncMap())
+	_, err := tmpl.Parse(getValuesTableTemplates())
+	require.NoError(t, err)
+
+	data := chartTemplateData{
+		Values: []valueRow{
+			{
+				Key:         "command",
+				Type:        "string",
+				Default:     "`\"a|b\"`",
+				Description: "matches a|b",
+			},
+		},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, tmpl.ExecuteTemplate(&buf, "chart.valuesTable", data))
+
+	out := buf.String()
+	assert.Contains(t, out, "`\"a\\|b\"`")
+	assert.Contains(t, out, "matches a\\|b")
+	assert.NotContains(t, out, "`\"a|b\"`")
 }

--- a/pkg/util/funcs.go
+++ b/pkg/util/funcs.go
@@ -12,7 +12,14 @@ func FuncMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	f["toYaml"] = toYAML
 	f["fromYaml"] = fromYAML
+	f["escapeMarkdownTableCell"] = escapeMarkdownTableCell
 	return f
+}
+
+// escapeMarkdownTableCell escapes characters that would otherwise break a
+// Markdown table row, namely the pipe character used as a column separator.
+func escapeMarkdownTableCell(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
 }
 
 // toYAML takes an interface, marshals it to yaml, and returns a string. It will


### PR DESCRIPTION
## Proposed changes

A pipe character in a `values.yaml` value (or in a `# --` description) is currently emitted verbatim into the Markdown values table, where it is parsed as a column separator and breaks the row layout. This escapes `|` as `\|` when rendering the Default and Description cells of the Markdown table. Closes #171

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/norwoodj/helm-docs/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The escape is applied only in the `*RenderMd` column templates, so the HTML output renderer is unaffected.
