### PR TITLE
feat: add support for section propagation and sectionDescription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /helm-docs
 /cmd/helm-docs/helm-docs
+/cmd/helm-docs/helm-docs.exe
 dist
 .idea/
 *.iml

--- a/example-charts/sections-description/Chart.yaml
+++ b/example-charts/sections-description/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: sections-description
+version: "1.0.0"
+type: application
+appVersion: "13.0.0"
+description: A chart for showing how to use sections with description
+home: "https://github.com/norwoodj/helm-docs/tree/master/example-charts/sections-description"
+maintainers:
+  - email: norwood.john.m@gmail.com
+    name: John Norwood
+sources: ["https://github.com/norwoodj/helm-docs/tree/master/example-charts/sections-description"]
+engine: gotpl

--- a/example-charts/sections-description/README.md
+++ b/example-charts/sections-description/README.md
@@ -2,27 +2,30 @@
 
 This creates values, but sectioned into own section tables if a section comment is provided.
 
+Also demonstrates use of `@sectionDescription` annotation for sections, and propagation of section tag to children of lists and objects.
+
 ## Values
 
 ### Some Section
-
   
 SomeSection has a description  
 It will have multiple lines, and it will be rendered in the documentation with newlines preserved.  
   
-It can have multiple paragraphs - and can be closed with a closing tag, so you can continue with regular description
+It can have multiple paragraphs  
+> It supports any markdown syntax
   
-This is another paragraph for the same section - this one is closed by a different tag  
+This is another paragraph for the same section  
 It's better to use just one description tag per section, as the order depends on the sort, but you can have descriptions separated and related to different values if you want
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controller.extraVolumes[0].configMap.name | string | `"nginx-ingress-config"` | Uses the name of the configmap created by this chart |
+| controller.extraVolumes[0].configMap.name | string | `"nginx-ingress-config"` | section gets propagated to this value,  to propagate, the ancestor needs to have `# --` comment even if it's not supposed to be added to the documentation  |
+| controller.extraVolumes[0].name | string | `"config-volume"` |  |
 | controller.persistentVolumeClaims | list | the chart will construct this list internally unless specified | List of persistent volume claims to create. The Regular description continues here |
 | controller.podLabels | object | empty map | The labels to be applied to instances of the controller pod |
+| controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" | string | `"stupidchess.jmn23.com"` | Hostname to be assigned to the ELB for the service |
 
 ### Special Attention
-
   
 This section has a list:  
 * Item 1  
@@ -35,13 +38,191 @@ This section has a list:
 | controller.publishService | object | `{"enabled":false}` | This is a publishService |
 | controller.replicas | int | `nil` | Number of nginx-ingress pods to load balance between |
 
+### Different nested Section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.service.type | string | `"LoadBalancer"` | Nested section can be different if specified |
+
 ### Other Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controller.extraVolumes[0].name | string | `"config-volume"` |  |
 | controller.image.repository | string | `"nginx-ingress-controller"` |  |
 | controller.image.tag | string | `"18.0831"` |  |
 | controller.name | string | `"controller"` |  |
-| controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" | string | `"stupidchess.jmn23.com"` | Hostname to be assigned to the ELB for the service |
-| controller.service.type | string | `"LoadBalancer"` |  |
+
+## Values
+
+<h3>Some Section</h3>
+  
+SomeSection has a description  
+It will have multiple lines, and it will be rendered in the documentation with newlines preserved.  
+  
+It can have multiple paragraphs  
+> It supports any markdown syntax
+  
+This is another paragraph for the same section  
+It's better to use just one description tag per section, as the order depends on the sort, but you can have descriptions separated and related to different values if you want
+
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td>controller.extraVolumes[0].configMap.name</td>
+			<td>string</td>
+			<td><pre lang="json">
+"nginx-ingress-config"
+</pre>
+</td>
+			<td>section gets propagated to this value,  to propagate, the ancestor needs to have `# --` comment even if it's not supposed to be added to the documentation </td>
+		</tr>
+		<tr>
+			<td>controller.extraVolumes[0].name</td>
+			<td>string</td>
+			<td><pre lang="json">
+"config-volume"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>controller.persistentVolumeClaims</td>
+			<td>list</td>
+			<td><pre lang="">
+the chart will construct this list internally unless specified
+</pre>
+</td>
+			<td>List of persistent volume claims to create. The Regular description continues here</td>
+		</tr>
+		<tr>
+			<td>controller.podLabels</td>
+			<td>object</td>
+			<td><pre lang="">
+empty map
+</pre>
+</td>
+			<td>The labels to be applied to instances of the controller pod</td>
+		</tr>
+		<tr>
+			<td>controller.service.annotations."external-dns.alpha.kubernetes.io/hostname"</td>
+			<td>string</td>
+			<td><pre lang="json">
+"stupidchess.jmn23.com"
+</pre>
+</td>
+			<td>Hostname to be assigned to the ELB for the service</td>
+		</tr>
+	</tbody>
+</table>
+<h3>Special Attention</h3>
+  
+This section has a list:  
+* Item 1  
+* Item 2  
+* Item 3
+
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td>controller.ingressClass</td>
+			<td>string</td>
+			<td><pre lang="json">
+"nginx"
+</pre>
+</td>
+			<td>You can also specify value comments like this</td>
+		</tr>
+		<tr>
+			<td>controller.publishService</td>
+			<td>object</td>
+			<td><pre lang="json">
+{
+  "enabled": false
+}
+</pre>
+</td>
+			<td>This is a publishService</td>
+		</tr>
+		<tr>
+			<td>controller.replicas</td>
+			<td>int</td>
+			<td><pre lang="json">
+null
+</pre>
+</td>
+			<td>Number of nginx-ingress pods to load balance between</td>
+		</tr>
+	</tbody>
+</table>
+<h3>Different nested Section</h3>
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td>controller.service.type</td>
+			<td>string</td>
+			<td><pre lang="json">
+"LoadBalancer"
+</pre>
+</td>
+			<td>Nested section can be different if specified</td>
+		</tr>
+	</tbody>
+</table>
+
+<h3>Other Values</h3>
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+	<tr>
+		<td>controller.image.repository</td>
+		<td>string</td>
+		<td><pre lang="json">
+"nginx-ingress-controller"
+</pre>
+</td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>controller.image.tag</td>
+		<td>string</td>
+		<td><pre lang="json">
+"18.0831"
+</pre>
+</td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>controller.name</td>
+		<td>string</td>
+		<td><pre lang="json">
+"controller"
+</pre>
+</td>
+		<td></td>
+	</tr>
+	</tbody>
+</table>
+

--- a/example-charts/sections-description/README.md
+++ b/example-charts/sections-description/README.md
@@ -1,0 +1,47 @@
+# Sections
+
+This creates values, but sectioned into own section tables if a section comment is provided.
+
+## Values
+
+### Some Section
+
+  
+SomeSection has a description  
+It will have multiple lines, and it will be rendered in the documentation with newlines preserved.  
+  
+It can have multiple paragraphs - and can be closed with a closing tag, so you can continue with regular description
+  
+This is another paragraph for the same section - this one is closed by a different tag  
+It's better to use just one description tag per section, as the order depends on the sort, but you can have descriptions separated and related to different values if you want
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.extraVolumes[0].configMap.name | string | `"nginx-ingress-config"` | Uses the name of the configmap created by this chart |
+| controller.persistentVolumeClaims | list | the chart will construct this list internally unless specified | List of persistent volume claims to create. The Regular description continues here |
+| controller.podLabels | object | empty map | The labels to be applied to instances of the controller pod |
+
+### Special Attention
+
+  
+This section has a list:  
+* Item 1  
+* Item 2  
+* Item 3
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.ingressClass | string | `"nginx"` | You can also specify value comments like this |
+| controller.publishService | object | `{"enabled":false}` | This is a publishService |
+| controller.replicas | int | `nil` | Number of nginx-ingress pods to load balance between |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controller.extraVolumes[0].name | string | `"config-volume"` |  |
+| controller.image.repository | string | `"nginx-ingress-controller"` |  |
+| controller.image.tag | string | `"18.0831"` |  |
+| controller.name | string | `"controller"` |  |
+| controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" | string | `"stupidchess.jmn23.com"` | Hostname to be assigned to the ELB for the service |
+| controller.service.type | string | `"LoadBalancer"` |  |

--- a/example-charts/sections-description/README.md.gotmpl
+++ b/example-charts/sections-description/README.md.gotmpl
@@ -1,0 +1,5 @@
+# Sections
+
+This creates values, but sectioned into own section tables if a section comment is provided.
+
+{{ template "chart.valuesSection" . }}

--- a/example-charts/sections-description/README.md.gotmpl
+++ b/example-charts/sections-description/README.md.gotmpl
@@ -1,5 +1,9 @@
 # Sections
 
-This creates values, but sectioned into own section tables if a section comment is provided.
+This creates values, but sectioned into own section tables if a section comment is provided. 
+
+Also demonstrates use of `@sectionDescription` annotation for sections, and propagation of section tag to children of lists and objects.
 
 {{ template "chart.valuesSection" . }}
+
+{{ template "chart.valuesSectionHtml" . }}

--- a/example-charts/sections-description/values.yaml
+++ b/example-charts/sections-description/values.yaml
@@ -7,37 +7,36 @@ controller:
   # controller.persistentVolumeClaims -- List of persistent volume claims to create.
   # @default -- the chart will construct this list internally unless specified
   # @section -- Some Section
-  # @sectionDescription
-  # SomeSection has a description
-  # It will have multiple lines, and it will be rendered in the documentation with newlines preserved.
-  # 
-  # It can have multiple paragraphs - and can be closed with a closing tag, so you can continue with regular description
-  # @sectionDescription
+  # @sectionDescription -- SomeSection has a description
+  # @sectionDescription -- It will have multiple lines, and it will be rendered in the documentation with newlines preserved.
+  # @sectionDescription -- 
+  # @sectionDescription -- It can have multiple paragraphs
+  # @sectionDescription -- > It supports any markdown syntax
   # The Regular description continues here
   persistentVolumeClaims: []
 
+  # --
+  # @section -- Some Section
   extraVolumes:
     - name: config-volume
       configMap:
-        # controller.extraVolumes[0].configMap.name -- Uses the name of the configmap created by this chart
-        # @section -- Some Section
+        # controller.extraVolumes[0].configMap.name -- section gets propagated to this value, 
+        # to propagate, the ancestor needs to have `# --` comment even if it's not supposed to be added to the documentation 
         name: nginx-ingress-config
 
   # -- You can also specify value comments like this
   # @section -- Special Attention
-  # @sectionDescription
-  # This section has a list:
-  # * Item 1
-  # * Item 2
-  # * Item 3
+  # @sectionDescription -- This section has a list:
+  # @sectionDescription -- * Item 1
+  # @sectionDescription -- * Item 2
+  # @sectionDescription -- * Item 3
   ingressClass: nginx
 
 
   # controller.podLabels -- The labels to be applied to instances of the controller pod
   # @section -- Some Section
-  # @sectionDescription
-  # This is another paragraph for the same section - this one is closed by a different tag
-  # It's better to use just one description tag per section, as the order depends on the sort, but you can have descriptions separated and related to different values if you want
+  # @sectionDescription -- This is another paragraph for the same section
+  # @sectionDescription -- It's better to use just one description tag per section, as the order depends on the sort, but you can have descriptions separated and related to different values if you want
   # @default -- empty map
   podLabels: {}
 
@@ -51,9 +50,13 @@ controller:
   # @section -- Special Attention
   replicas:
 
+  # --
+  # @section -- Some Section
   service:
     annotations:
       # controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" -- Hostname to be assigned to the ELB for the service
       external-dns.alpha.kubernetes.io/hostname: stupidchess.jmn23.com
-
+    
+    # -- Nested section can be different if specified
+    # @section -- Different nested Section
     type: LoadBalancer

--- a/example-charts/sections-description/values.yaml
+++ b/example-charts/sections-description/values.yaml
@@ -1,0 +1,59 @@
+controller:
+  name: controller
+  image:
+    repository: nginx-ingress-controller
+    tag: "18.0831"
+
+  # controller.persistentVolumeClaims -- List of persistent volume claims to create.
+  # @default -- the chart will construct this list internally unless specified
+  # @section -- Some Section
+  # @sectionDescription
+  # SomeSection has a description
+  # It will have multiple lines, and it will be rendered in the documentation with newlines preserved.
+  # 
+  # It can have multiple paragraphs - and can be closed with a closing tag, so you can continue with regular description
+  # @sectionDescription
+  # The Regular description continues here
+  persistentVolumeClaims: []
+
+  extraVolumes:
+    - name: config-volume
+      configMap:
+        # controller.extraVolumes[0].configMap.name -- Uses the name of the configmap created by this chart
+        # @section -- Some Section
+        name: nginx-ingress-config
+
+  # -- You can also specify value comments like this
+  # @section -- Special Attention
+  # @sectionDescription
+  # This section has a list:
+  # * Item 1
+  # * Item 2
+  # * Item 3
+  ingressClass: nginx
+
+
+  # controller.podLabels -- The labels to be applied to instances of the controller pod
+  # @section -- Some Section
+  # @sectionDescription
+  # This is another paragraph for the same section - this one is closed by a different tag
+  # It's better to use just one description tag per section, as the order depends on the sort, but you can have descriptions separated and related to different values if you want
+  # @default -- empty map
+  podLabels: {}
+
+  # controller.publishService -- This is a publishService
+  # @section -- Special Attention
+  publishService:
+    enabled: false
+
+  # -- (int) Number of nginx-ingress pods to load balance between
+  # @raw
+  # @section -- Special Attention
+  replicas:
+
+  service:
+    annotations:
+      # controller.service.annotations."external-dns.alpha.kubernetes.io/hostname" -- Hostname to be assigned to the ELB for the service
+      external-dns.alpha.kubernetes.io/hostname: stupidchess.jmn23.com
+
+    type: LoadBalancer

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -13,18 +13,19 @@ import (
 )
 
 type valueRow struct {
-	Key             string
-	Type            string
-	NotationType    string
-	AutoDefault     string
-	Default         string
-	AutoDescription string
-	Description     string
-	Section         string
-	Column          int
-	LineNumber      int
-	Dependency      string
-	IsGlobal        bool
+	Key                string
+	Type               string
+	NotationType       string
+	AutoDefault        string
+	Default            string
+	AutoDescription    string
+	Description        string
+	Section            string
+	SectionDescription string
+	Column             int
+	LineNumber         int
+	Dependency         string
+	IsGlobal           bool
 }
 
 type chartTemplateData struct {
@@ -42,8 +43,9 @@ type sections struct {
 }
 
 type section struct {
-	SectionName  string
-	SectionItems []valueRow
+	SectionName         string
+	SectionDescriptions []string
+	SectionItems        []valueRow
 }
 
 func sortValueRowsByOrder(valueRows []valueRow, sortOrder string) {
@@ -143,6 +145,8 @@ func getSectionedValueRows(valueRows []valueRow) sections {
 		SectionItems: []valueRow{},
 	}
 
+	sectionDescriptionMap := make(map[string][]string)
+
 	for _, row := range valueRows {
 		if row.Section == "" {
 			valueRowsSectionSorted.DefaultSection.SectionItems = append(valueRowsSectionSorted.DefaultSection.SectionItems, row)
@@ -164,6 +168,19 @@ func getSectionedValueRows(valueRows []valueRow) sections {
 				SectionItems: []valueRow{row},
 			})
 		}
+
+		if row.SectionDescription != "" {
+			sectionDescriptionMap[row.Section] = append(sectionDescriptionMap[row.Section], row.SectionDescription)
+		}
+	}
+
+	for i, section := range valueRowsSectionSorted.Sections {
+		sectionDescriptions, exists := sectionDescriptionMap[section.SectionName]
+		if !exists {
+			continue
+		}
+
+		valueRowsSectionSorted.Sections[i].SectionDescriptions = sectionDescriptions
 	}
 
 	return valueRowsSectionSorted

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -2,6 +2,7 @@ package document
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -13,19 +14,19 @@ import (
 )
 
 type valueRow struct {
-	Key                string
-	Type               string
-	NotationType       string
-	AutoDefault        string
-	Default            string
-	AutoDescription    string
-	Description        string
-	Section            string
-	SectionDescription string
-	Column             int
-	LineNumber         int
-	Dependency         string
-	IsGlobal           bool
+	Key                 string
+	Type                string
+	NotationType        string
+	AutoDefault         string
+	Default             string
+	AutoDescription     string
+	Description         string
+	Section             string
+	SectionDescriptions []*string
+	Column              int
+	LineNumber          int
+	Dependency          string
+	IsGlobal            bool
 }
 
 type chartTemplateData struct {
@@ -44,7 +45,7 @@ type sections struct {
 
 type section struct {
 	SectionName         string
-	SectionDescriptions []string
+	SectionDescriptions []*string
 	SectionItems        []valueRow
 }
 
@@ -145,7 +146,7 @@ func getSectionedValueRows(valueRows []valueRow) sections {
 		SectionItems: []valueRow{},
 	}
 
-	sectionDescriptionMap := make(map[string][]string)
+	sectionDescriptionMap := make(map[string][]*string)
 
 	for _, row := range valueRows {
 		if row.Section == "" {
@@ -169,8 +170,15 @@ func getSectionedValueRows(valueRows []valueRow) sections {
 			})
 		}
 
-		if row.SectionDescription != "" {
-			sectionDescriptionMap[row.Section] = append(sectionDescriptionMap[row.Section], row.SectionDescription)
+		if len(row.SectionDescriptions) > 0 {
+			if sectionDescriptionMap[row.Section] == nil {
+				sectionDescriptionMap[row.Section] = []*string{}
+			}
+			for _, desc := range row.SectionDescriptions {
+				if !slices.Contains(sectionDescriptionMap[row.Section], desc) {
+					sectionDescriptionMap[row.Section] = append(sectionDescriptionMap[row.Section], desc)
+				}
+			}
 		}
 	}
 

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -226,8 +226,8 @@ func getValuesTableTemplates() string {
 
 	valuesSectionBuilder.WriteString(`{{ define "chart.sectionDescriptionTemplate" }}`)
 	valuesSectionBuilder.WriteString("{{- range .SectionDescriptions }}")
-	valuesSectionBuilder.WriteString("\n{{ . }}\n")
-	valuesSectionBuilder.WriteString("{{- end }}")
+	valuesSectionBuilder.WriteString("{{ . }}\n")
+	valuesSectionBuilder.WriteString("{{ end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 
 	valuesSectionBuilder.WriteString(`{{ define "chart.valuesTable" }}`)
@@ -235,9 +235,8 @@ func getValuesTableTemplates() string {
 	valuesSectionBuilder.WriteString("{{ range .Sections.Sections }}")
 	valuesSectionBuilder.WriteString("\n")
 	valuesSectionBuilder.WriteString("\n### {{ .SectionName }}\n")
-	valuesSectionBuilder.WriteString("\n")
 	valuesSectionBuilder.WriteString(`{{ template "chart.sectionDescriptionTemplate" . }}`)
-	valuesSectionBuilder.WriteString("\n\n")
+	valuesSectionBuilder.WriteString("\n")
 	valuesSectionBuilder.WriteString("| Key | Type | Default | Description |\n")
 	valuesSectionBuilder.WriteString("|-----|------|---------|-------------|\n")
 	valuesSectionBuilder.WriteString("  {{- range .SectionItems }}")
@@ -316,7 +315,9 @@ func getValuesTableTemplates() string {
 {{ if .Sections.Sections }}
 {{- range .Sections.Sections }}
 <h3>{{- .SectionName }}</h3>
-<p>{{ template "chart.sectionDescriptionTemplate" . }}</p>
+{{- if .SectionDescriptions }}
+{{ template "chart.sectionDescriptionTemplate" . }}
+{{- end }}
 <table>
 	<thead>
 		<th>Key</th>

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -224,12 +224,20 @@ func getValuesTableTemplates() string {
 	valuesSectionBuilder.WriteString("{{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }}")
 	valuesSectionBuilder.WriteString("{{ end }}")
 
+	valuesSectionBuilder.WriteString(`{{ define "chart.sectionDescriptionTemplate" }}`)
+	valuesSectionBuilder.WriteString("{{- range .SectionDescriptions }}")
+	valuesSectionBuilder.WriteString("\n{{ . }}\n")
+	valuesSectionBuilder.WriteString("{{- end }}")
+	valuesSectionBuilder.WriteString("{{ end }}")
+
 	valuesSectionBuilder.WriteString(`{{ define "chart.valuesTable" }}`)
 	valuesSectionBuilder.WriteString("{{ if .Sections.Sections }}")
 	valuesSectionBuilder.WriteString("{{ range .Sections.Sections }}")
 	valuesSectionBuilder.WriteString("\n")
 	valuesSectionBuilder.WriteString("\n### {{ .SectionName }}\n")
 	valuesSectionBuilder.WriteString("\n")
+	valuesSectionBuilder.WriteString(`{{ template "chart.sectionDescriptionTemplate" . }}`)
+	valuesSectionBuilder.WriteString("\n\n")
 	valuesSectionBuilder.WriteString("| Key | Type | Default | Description |\n")
 	valuesSectionBuilder.WriteString("|-----|------|---------|-------------|\n")
 	valuesSectionBuilder.WriteString("  {{- range .SectionItems }}")
@@ -308,6 +316,7 @@ func getValuesTableTemplates() string {
 {{ if .Sections.Sections }}
 {{- range .Sections.Sections }}
 <h3>{{- .SectionName }}</h3>
+<p>{{ template "chart.sectionDescriptionTemplate" . }}</p>
 <table>
 	<thead>
 		<th>Key</th>

--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -191,23 +191,23 @@ func createValueRow(
 		section = autoDescription.Section
 	}
 
-	sectionDescription := description.SectionDescription
-	if sectionDescription == "" && autoDescription.SectionDescription != "" {
-		sectionDescription = autoDescription.SectionDescription
+	sectionDescriptions := description.SectionDescriptions
+	if len(sectionDescriptions) == 0 && len(autoDescription.SectionDescriptions) > 0 {
+		sectionDescriptions = autoDescription.SectionDescriptions
 	}
 
 	return valueRow{
-		Key:                key,
-		Type:               defaultType,
-		NotationType:       notationType,
-		AutoDefault:        autoDescription.Default,
-		Default:            defaultValue,
-		AutoDescription:    autoDescription.Description,
-		Description:        description.Description,
-		Section:            section,
-		SectionDescription: sectionDescription,
-		Column:             column,
-		LineNumber:         lineNumber,
+		Key:                 key,
+		Type:                defaultType,
+		NotationType:        notationType,
+		AutoDefault:         autoDescription.Default,
+		Default:             defaultValue,
+		AutoDescription:     autoDescription.Description,
+		Description:         description.Description,
+		Section:             section,
+		SectionDescriptions: sectionDescriptions,
+		Column:              column,
+		LineNumber:          lineNumber,
 	}, nil
 }
 
@@ -296,6 +296,28 @@ func createValueRowsFromList(
 		valueRows = append(valueRows, valueRowsForListField...)
 	}
 
+	section := description.Section
+	if section == "" && autoDescription.Section != "" {
+		section = autoDescription.Section
+	}
+
+	sectionDescriptions := description.SectionDescriptions
+	if len(sectionDescriptions) == 0 && len(autoDescription.SectionDescriptions) > 0 {
+		sectionDescriptions = autoDescription.SectionDescriptions
+	}
+	prependSectionsDescription := len(sectionDescriptions) > 0
+
+	if section != "" {
+		for i := range valueRows {
+			if valueRows[i].Section == "" {
+				valueRows[i].Section = section
+				if prependSectionsDescription {
+					valueRows[i].SectionDescriptions = append(sectionDescriptions, valueRows[i].SectionDescriptions...)
+					prependSectionsDescription = false // only add once per section
+				}
+			}
+		}
+	}
 	return valueRows, nil
 }
 
@@ -388,6 +410,28 @@ func createValueRowsFromObject(
 		valueRows = append(valueRows, valueRowsForObjectField...)
 	}
 
+	section := description.Section
+	if section == "" && autoDescription.Section != "" {
+		section = autoDescription.Section
+	}
+
+	sectionDescriptions := description.SectionDescriptions
+	if len(sectionDescriptions) == 0 && len(autoDescription.SectionDescriptions) > 0 {
+		sectionDescriptions = autoDescription.SectionDescriptions
+	}
+	prependSectionsDescription := len(sectionDescriptions) > 0
+
+	if section != "" {
+		for i := range valueRows {
+			if valueRows[i].Section == "" {
+				valueRows[i].Section = section
+				if prependSectionsDescription {
+					valueRows[i].SectionDescriptions = append(sectionDescriptions, valueRows[i].SectionDescriptions...)
+					prependSectionsDescription = false // only add once per section
+				}
+			}
+		}
+	}
 	return valueRows, nil
 }
 

--- a/pkg/document/values.go
+++ b/pkg/document/values.go
@@ -191,17 +191,23 @@ func createValueRow(
 		section = autoDescription.Section
 	}
 
+	sectionDescription := description.SectionDescription
+	if sectionDescription == "" && autoDescription.SectionDescription != "" {
+		sectionDescription = autoDescription.SectionDescription
+	}
+
 	return valueRow{
-		Key:             key,
-		Type:            defaultType,
-		NotationType:    notationType,
-		AutoDefault:     autoDescription.Default,
-		Default:         defaultValue,
-		AutoDescription: autoDescription.Description,
-		Description:     description.Description,
-		Section:         section,
-		Column:          column,
-		LineNumber:      lineNumber,
+		Key:                key,
+		Type:               defaultType,
+		NotationType:       notationType,
+		AutoDefault:        autoDescription.Default,
+		Default:            defaultValue,
+		AutoDescription:    autoDescription.Description,
+		Description:        description.Description,
+		Section:            section,
+		SectionDescription: sectionDescription,
+		Column:             column,
+		LineNumber:         lineNumber,
 	}, nil
 }
 

--- a/pkg/helm/chart_info.go
+++ b/pkg/helm/chart_info.go
@@ -22,7 +22,7 @@ var defaultValueRegex = regexp.MustCompile("^\\s*# @default -- (.*)$")
 var valueTypeRegex = regexp.MustCompile("^\\((.*?)\\)\\s*(.*)$")
 var valueNotationTypeRegex = regexp.MustCompile("^\\s*#\\s+@notationType\\s+--\\s+(.*)$")
 var sectionRegex = regexp.MustCompile("^\\s*# @section -- (.*)$")
-var sectionDescriptionRegex = regexp.MustCompile("^\\s*# @sectionDescription")
+var sectionDescriptionRegex = regexp.MustCompile("^\\s*# @sectionDescription -- (.*)$")
 
 type ChartMetaMaintainer struct {
 	Email string
@@ -57,12 +57,12 @@ type ChartRequirements struct {
 }
 
 type ChartValueDescription struct {
-	Description        string
-	Default            string
-	Section            string
-	SectionDescription string
-	ValueType          string
-	NotationType       string
+	Description         string
+	Default             string
+	Section             string
+	SectionDescriptions []*string
+	ValueType           string
+	NotationType        string
 }
 
 type ChartDocumentationInfo struct {

--- a/pkg/helm/chart_info.go
+++ b/pkg/helm/chart_info.go
@@ -22,6 +22,7 @@ var defaultValueRegex = regexp.MustCompile("^\\s*# @default -- (.*)$")
 var valueTypeRegex = regexp.MustCompile("^\\((.*?)\\)\\s*(.*)$")
 var valueNotationTypeRegex = regexp.MustCompile("^\\s*#\\s+@notationType\\s+--\\s+(.*)$")
 var sectionRegex = regexp.MustCompile("^\\s*# @section -- (.*)$")
+var sectionDescriptionRegex = regexp.MustCompile("^\\s*# @sectionDescription")
 
 type ChartMetaMaintainer struct {
 	Email string
@@ -56,11 +57,12 @@ type ChartRequirements struct {
 }
 
 type ChartValueDescription struct {
-	Description  string
-	Default      string
-	Section      string
-	ValueType    string
-	NotationType string
+	Description        string
+	Default            string
+	Section            string
+	SectionDescription string
+	ValueType          string
+	NotationType       string
 }
 
 type ChartDocumentationInfo struct {

--- a/pkg/helm/comment.go
+++ b/pkg/helm/comment.go
@@ -44,7 +44,7 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 		c.Description = valueTypeMatch[2]
 	}
 
-	var isRaw, isSectionDescription = false, false
+	isRaw, isSectionDescription, sectionDescriptionIndex := false, false, -1
 
 	for _, line := range commentLines[docStartIdx+1:] {
 		rawFlagMatch := rawDescriptionRegex.FindStringSubmatch(line)
@@ -52,6 +52,18 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 		notationTypeCommentMatch := valueNotationTypeRegex.FindStringSubmatch(line)
 		sectionCommentMatch := sectionRegex.FindStringSubmatch(line)
 		sectionDescriptionMatch := sectionDescriptionRegex.FindStringSubmatch(line)
+
+		if len(sectionDescriptionMatch) > 1 {
+			if !isSectionDescription {
+				c.SectionDescriptions = append(c.SectionDescriptions, new(string))
+				sectionDescriptionIndex++
+				isSectionDescription = true
+			}
+			*c.SectionDescriptions[sectionDescriptionIndex] += "   \n" + sectionDescriptionMatch[1]
+			continue
+		} else {
+			isSectionDescription = false
+		}
 
 		if !isRaw && len(rawFlagMatch) == 1 {
 			isRaw = true
@@ -73,21 +85,7 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 			continue
 		}
 
-		if len(sectionDescriptionMatch) > 0 {
-			isSectionDescription = !isSectionDescription
-			continue
-		}
-
 		commentContinuationMatch := commentContinuationRegex.FindStringSubmatch(line)
-
-		if isSectionDescription {
-			if len(commentContinuationMatch) > 1 {
-				c.SectionDescription += "   \n" + commentContinuationMatch[2]
-				continue
-			} else {
-				isSectionDescription = false
-			}
-		}
 
 		if isRaw {
 

--- a/pkg/helm/comment.go
+++ b/pkg/helm/comment.go
@@ -44,13 +44,14 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 		c.Description = valueTypeMatch[2]
 	}
 
-	var isRaw = false
+	var isRaw, isSectionDescription = false, false
 
 	for _, line := range commentLines[docStartIdx+1:] {
 		rawFlagMatch := rawDescriptionRegex.FindStringSubmatch(line)
 		defaultCommentMatch := defaultValueRegex.FindStringSubmatch(line)
 		notationTypeCommentMatch := valueNotationTypeRegex.FindStringSubmatch(line)
 		sectionCommentMatch := sectionRegex.FindStringSubmatch(line)
+		sectionDescriptionMatch := sectionDescriptionRegex.FindStringSubmatch(line)
 
 		if !isRaw && len(rawFlagMatch) == 1 {
 			isRaw = true
@@ -72,7 +73,21 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 			continue
 		}
 
+		if len(sectionDescriptionMatch) > 0 {
+			isSectionDescription = !isSectionDescription
+			continue
+		}
+
 		commentContinuationMatch := commentContinuationRegex.FindStringSubmatch(line)
+
+		if isSectionDescription {
+			if len(commentContinuationMatch) > 1 {
+				c.SectionDescription += "   \n" + commentContinuationMatch[2]
+				continue
+			} else {
+				isSectionDescription = false
+			}
+		}
 
 		if isRaw {
 


### PR DESCRIPTION
Adds support for passing `@section` annotation down through list items and object properties, reducing the amount of annotations needed.

Also implements `@sectionDescription` annotation, allowing multiline markdown descriptions. To comply with the rest of the tags, it's implemented like this:

```yaml
# podAnnotations -- (object) Additional pod annotations. Can be used for various purposes.
# @section -- Pod settings
# @sectionDescription -- Pod customization settings, such as annotations, resource requests and limits, probes, extra containers and initContainers, affinity and tolerations. Each of these are added to the pod spec as-is, so any valid Kubernetes configuration can be used here.
# @sectionDescription -- 
# @sectionDescription -- Each field in this section is optional, and can be left empty if not needed, but we recommend adding at least the probes, and custom resource requests and limits for better observability and stability of the application.
# @sectionDescription -- 
# @sectionDescription -- Affinity and tolerations can be used to control pod scheduling and placement, if using a custom node pool.
podAnnotations: {}
```

I previously implemented it as so, which made it more readable in my opinion, also allowed adding multiple descriptions in one object (for use with custom rendering)

```yaml
# -- (object)
# @section -- Security and identity settings
# @sectionDescription 
# The automount of serviceaccount tokens is disabled. If you need to create a short-lived token for your pod or sidecars (more likely scenario), you need to set `serviceAccountToken.use: true`. This creates a volume called **token-volume** with token and ca bundle.
#  To mount it in your app (but you will probably not need this), you can use `serviceAccountToken.mount: "<path-to-mount>"`.
# @sectionDescription
# @sectionDescription
#  In following example we show how to set up **DAPR** sidecar for reading secrets and 3rd party extraInitContainer:
# ```yaml
# serviceAccountToken:
#   use: true
# 
# podAnnotations:
#   ...
#   dapr.io/volume-mounts: "token-volume:/var/run/secrets/kubernetes.io/serviceaccount"
# 
# extraInitContainers:
#   ...
#   volumeMounts:
#     - name: token-volume
#       mountPath: "/var/run/secrets/kubernetes.io/serviceaccount" # Or different if it supports custom path
#       readOnly: true
# ```
# @sectionDescription
# Regular description continues here
serviceAccountToken:
  # serviceAccountToken.use -- (bool) Whether to create a projected service account token volume.
  use: false
```

If this would be preferred way to use it, I can do the change

Fixes #227, #264