### PR TITLE
Ensure generated docs end with a single trailing newline

### DIFF
--- a/pkg/document/generate.go
+++ b/pkg/document/generate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/norwoodj/helm-docs/pkg/helm"
 	log "github.com/sirupsen/logrus"
@@ -77,6 +78,10 @@ func applyMarkDownFormat(output bytes.Buffer) bytes.Buffer {
 
 	re = regexp.MustCompile(`\n{3,}`)
 	outputString = re.ReplaceAllString(outputString, "\n\n")
+
+	// End the file with a single trailing newline so it doesn't fight tools
+	// that enforce that (for example pre-commit's end-of-file-fixer).
+	outputString = strings.TrimRight(outputString, "\n") + "\n"
 
 	output.Reset()
 	output.WriteString(outputString)

--- a/pkg/document/generate_test.go
+++ b/pkg/document/generate_test.go
@@ -1,0 +1,51 @@
+package document
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyMarkDownFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "collapses trailing blank lines into a single newline",
+			in:   "# Chart\n\n| key | value |\n\n\n",
+			want: "# Chart\n\n| key | value |\n",
+		},
+		{
+			name: "adds a trailing newline when missing",
+			in:   "# Chart",
+			want: "# Chart\n",
+		},
+		{
+			name: "keeps a single trailing newline untouched",
+			in:   "# Chart\n",
+			want: "# Chart\n",
+		},
+		{
+			name: "still strips trailing space before a newline",
+			in:   "trailing space \nnext\n",
+			want: "trailing space\nnext\n",
+		},
+		{
+			name: "still collapses three or more blank lines in the body",
+			in:   "a\n\n\n\nb\n",
+			want: "a\n\nb\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			buf.WriteString(tt.in)
+			got := applyMarkDownFormat(buf)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #135.

The generated README could end with two newlines instead of one. That trips up tools that enforce a single final newline, most notably pre-commit's end-of-file-fixer, which then rewrites the file on every run and gets stuck fighting helm-docs.

`applyMarkDownFormat` already collapses runs of blank lines, but `\n{3,}` -> `\n\n` still leaves a trailing double newline at the end of the file. This normalizes the very end to exactly one newline after the existing formatting runs, so it also covers custom templates and the HTML values section.

Added a small table test for `applyMarkDownFormat` covering the trailing newline cases plus the existing space-before-newline and blank-line collapsing behavior so those don't regress.